### PR TITLE
[CHORE] Add CODEOWNERS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+
+  # Maintain GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "bot"
+    commit-message:
+      prefix: "[CHORE](deps)"
+      include: "scope"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @overturemaps/omf-public-reviewers


### PR DESCRIPTION
* Added `.github/dependabot.yml` to configure Dependabot for weekly GitHub Actions dependency updates, limiting open PRs and labeling them as "bot".

* Updated `CODEOWNERS` to assign default ownership of all files to the `@overturemaps/omf-public-reviewers` team.

Partially resolves https://github.com/OvertureMaps/ops-team/issues/274