### PR TITLE
[BUG] Remove redundant borrow in sink.rs format! call

### DIFF
--- a/osm-pbf-parquet/src/sink.rs
+++ b/osm-pbf-parquet/src/sink.rs
@@ -160,7 +160,7 @@ impl ElementSink {
     ) -> String {
         let trailing_path = Self::new_trailing_path(osm_type, filenum, compression != 0);
         // Remove trailing `/`s to avoid empty path segment
-        format!("{0}{trailing_path}", &output_path.trim_end_matches('/'))
+        format!("{0}{trailing_path}", output_path.trim_end_matches('/'))
     }
 
     fn new_trailing_path(


### PR DESCRIPTION
`trim_end_matches` already returns a `&str`, so the extra `&` in `create_full_path`'s `format!` call trips `clippy::useless_borrows_in_formatting`, which is denied via `-D warnings`. This has been failing the Lint job on `main` since the affected line was added.

Fixes #26.