### PR TITLE
[PERFORMANCE] Speed up vendored osmpbf decode with libdeflater and zero-copy reads

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -58,3 +58,20 @@ jobs:
       working-directory: ./osm-pbf-parquet/test
     - name: Benchmark
       run: cargo bench -p osm-pbf-parquet
+
+  build-and-test-arm:
+    name: Build and Test (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: lint
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+    - name: Build
+      run: cargo build --release -p osm-pbf-parquet
+    - name: Run unit tests
+      run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,11 +1676,13 @@ dependencies = [
  "criterion 0.3.6",
  "flate2",
  "futures-util",
+ "libdeflater",
  "memmap2",
  "object_store",
  "protobuf",
  "protobuf-codegen",
  "rayon",
+ "simdutf8",
  "tokio",
  "tokio-stream",
  "tokio-test",
@@ -2450,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,6 @@ dependencies = [
  "clap 4.6.5",
  "criterion 0.8.2",
  "env_logger",
- "flate2",
  "futures",
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ lto = "thin"
 codegen-units = 1
 
 [workspace.dependencies]
-osmpbf = { path = "osmpbf", default-features = false, features = ["zlib-ng", "async"] }
+osmpbf = { path = "osmpbf", default-features = false, features = ["rust-zlib", "async"] }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ SELECT * FROM osm LIMIT 10;
 
 
 ## Benchmarks
-osm-pbf-parquet prioritizes transcode speed over file size, file count or perserving ordering. Here is a comparison against similar tools on the 2024-06-24 OSM planet PBF with target file size of 500MB:
+osm-pbf-parquet prioritizes transcode speed over file size, file count or perserving ordering.
+
+On the 2026-02-02 OSM planet PBF (91GB, 11.58B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m18s** (4,580s CPU, 184GB output).
+
+Comparison against similar tools on the 2024-06-24 OSM planet PBF with target file size of 500MB:
 | | Time (wall) | Output size | File count |
 | - | - | - | - |
 | **osm-pbf-parquet** (zstd:3) | 30 minutes | 182GB | ~600 |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ SELECT * FROM osm LIMIT 10;
 
 
 ## Benchmarks
-osm-pbf-parquet prioritizes transcode speed over file size, file count or perserving ordering.
+osm-pbf-parquet prioritizes transcode speed over file size, file count or preserving ordering.
 
 On the 2026-02-02 OSM planet PBF (91GB, 11.58B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m18s** (4,580s CPU, 184GB output).
 

--- a/osm-pbf-parquet/Cargo.toml
+++ b/osm-pbf-parquet/Cargo.toml
@@ -10,7 +10,6 @@ arrow-schema = "59.1.0"
 bytes = "1.11.1"
 clap = { version = "4.5.58", features = ["derive"] }
 env_logger = "0.11.9"
-flate2 = { version = "1.1.9", features = ["zlib-ng"], default-features = false }
 futures = "0.3.32"
 futures-util = "0.3.32"
 log = "0.4.29"

--- a/osmpbf/Cargo.toml
+++ b/osmpbf/Cargo.toml
@@ -23,7 +23,9 @@ async-stream = { version = "0.3.6", optional = true }
 byteorder = "1.4"
 bytes = "1.10.1"
 flate2 = { version = "1.0", default-features = false }
+libdeflater = "1.25"
 memmap2 = "0.5"
+simdutf8 = "0.1"
 object_store = { version = "0.13", optional = true }
 protobuf = { version = "3.1", features = ["with-bytes"] }
 rayon = "1.5"

--- a/osmpbf/Cargo.toml
+++ b/osmpbf/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [features]
 async = ["async-stream", "object_store", "tokio", "tokio/io-util", "tokio-stream"]
-default = ["zlib-ng"]
+default = ["rust-zlib"]
 rust-zlib = ["flate2/rust_backend"]
 zlib = ["flate2/zlib"]
 zlib-ng = ["flate2/zlib-ng"]

--- a/osmpbf/src/blob.rs
+++ b/osmpbf/src/blob.rs
@@ -295,8 +295,18 @@ impl<R: Read + Send> Iterator for BlobReader<R> {
             None => return None,
         };
 
-        let mut reader = self.reader.by_ref().take(header.datasize() as u64);
-        let mut blob_data = Vec::with_capacity(header.datasize() as usize);
+        // datasize is untrusted i32 wire data: reject negative or oversized
+        // values before allocating
+        let datasize = header.datasize();
+        if datasize < 0 || datasize as u64 >= MAX_BLOB_MESSAGE_SIZE {
+            self.offset = None;
+            self.last_blob_ok = false;
+            return Some(Err(new_blob_error(BlobError::MessageTooBig {
+                size: datasize as u64,
+            })));
+        }
+        let mut reader = self.reader.by_ref().take(datasize as u64);
+        let mut blob_data = Vec::with_capacity(datasize as usize);
         if let Err(e) = reader.read_to_end(&mut blob_data) {
             return self.handle_decode_error(e.into(), "could not read from blob");
         }
@@ -575,7 +585,17 @@ impl AsyncBlobReader {
         // Read into an uninitialized BytesMut (no zero-fill) and parse with
         // parse_from_tokio_bytes so the compressed payload is a zero-copy,
         // refcounted slice of this buffer instead of a fresh allocation.
-        let datasize = header.datasize() as usize;
+        // datasize is untrusted i32 wire data: reject negative or oversized
+        // values before allocating
+        let datasize = header.datasize();
+        if datasize < 0 || datasize as u64 >= MAX_BLOB_MESSAGE_SIZE {
+            self.offset = None;
+            self.last_blob_ok = false;
+            return Some(Err(new_blob_error(BlobError::MessageTooBig {
+                size: datasize as u64,
+            })));
+        }
+        let datasize = datasize as usize;
         let mut buffer = bytes::BytesMut::with_capacity(datasize);
         {
             use bytes::BufMut;
@@ -583,7 +603,11 @@ impl AsyncBlobReader {
             while limited.has_remaining_mut() {
                 match self.reader.read_buf(&mut limited).await {
                     Ok(0) => {
-                        return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+                        self.offset = None;
+                        self.last_blob_ok = false;
+                        return Some(Err(
+                            std::io::Error::from(std::io::ErrorKind::UnexpectedEof).into()
+                        ));
                     }
                     Ok(_) => {}
                     Err(e) => {
@@ -678,18 +702,18 @@ pub(crate) fn decode_blob<T: Message>(blob: &fileformat::Blob) -> Result<T> {
 
 /// Decompress a zlib-compressed blob payload.
 ///
-/// When the blob carries `raw_size` (the exact uncompressed size, set by all
-/// mainstream OSM writers) we can decompress in a single shot into an
-/// exact-sized buffer with libdeflate, which is significantly faster than
-/// streaming inflate. Fall back to streaming flate2 when `raw_size` is
-/// missing or inconsistent.
+/// When the blob carries a plausible `raw_size` (the exact uncompressed size,
+/// set by all mainstream OSM writers) we can decompress in a single shot into
+/// an exact-sized buffer with libdeflate, which is significantly faster than
+/// streaming inflate. Fall back to streaming flate2 — which enforces its own
+/// size cap via `take` — when `raw_size` is missing, negative, oversized, or
+/// inconsistent, matching the pre-libdeflate behavior for such blobs.
 fn decompress_zlib(bytes: &Bytes, raw_size: Option<i32>) -> Result<Vec<u8>> {
-    if let Some(raw_size) = raw_size {
-        let size = raw_size as u64;
-        if size >= MAX_BLOB_MESSAGE_SIZE {
-            return Err(new_blob_error(BlobError::MessageTooBig { size }));
-        }
-        let mut decoded_bytes = vec![0u8; raw_size as usize];
+    let plausible_raw_size = raw_size
+        .and_then(|n| usize::try_from(n).ok())
+        .filter(|&n| (n as u64) < MAX_BLOB_MESSAGE_SIZE);
+    if let Some(raw_size) = plausible_raw_size {
+        let mut decoded_bytes = vec![0u8; raw_size];
         let mut decompressor = libdeflater::Decompressor::new();
         match decompressor.zlib_decompress(bytes, &mut decoded_bytes) {
             Ok(len) if len == decoded_bytes.len() => return Ok(decoded_bytes),

--- a/osmpbf/src/blob.rs
+++ b/osmpbf/src/blob.rs
@@ -572,20 +572,28 @@ impl AsyncBlobReader {
             None => return None,
         };
 
-        let mut buffer = vec![0; header.datasize() as usize];
-        let read_result = self.reader.read_exact(&mut buffer).await;
-        match read_result {
-            Ok(read_byte_count) => {
-                if read_byte_count != header.datasize() as usize {
-                    return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+        // Read into an uninitialized BytesMut (no zero-fill) and parse with
+        // parse_from_tokio_bytes so the compressed payload is a zero-copy,
+        // refcounted slice of this buffer instead of a fresh allocation.
+        let datasize = header.datasize() as usize;
+        let mut buffer = bytes::BytesMut::with_capacity(datasize);
+        {
+            use bytes::BufMut;
+            let mut limited = (&mut buffer).limit(datasize);
+            while limited.has_remaining_mut() {
+                match self.reader.read_buf(&mut limited).await {
+                    Ok(0) => {
+                        return Some(Err(new_blob_error(BlobError::InvalidHeaderSize)));
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Some(Err(e.into()));
+                    }
                 }
-            }
-            Err(e) => {
-                return Some(Err(e.into()));
             }
         }
 
-        let blob = match fileformat::Blob::parse_from_bytes(&buffer) {
+        let blob = match fileformat::Blob::parse_from_tokio_bytes(&buffer.freeze()) {
             Ok(blob) => blob,
             Err(e) => {
                 self.offset = None;
@@ -659,15 +667,40 @@ pub(crate) fn decode_blob<T: Message>(blob: &fileformat::Blob) -> Result<T> {
             }
         }
         Some(fileformat::blob::Data::ZlibData(bytes)) => {
-            let mut decoder = ZlibDecoder::new(&**bytes).take(MAX_BLOB_MESSAGE_SIZE);
-            let mut decoded_bytes = Vec::with_capacity(bytes.len());
-            decoder.read_to_end(&mut decoded_bytes)?;
+            let decoded_bytes = decompress_zlib(bytes, blob.raw_size)?;
 
             T::parse_from_tokio_bytes(&Bytes::from(decoded_bytes))
                 .map_err(|e| new_protobuf_error(e, "blob zlib data"))
         }
         _ => Err(new_blob_error(BlobError::Empty)),
     }
+}
+
+/// Decompress a zlib-compressed blob payload.
+///
+/// When the blob carries `raw_size` (the exact uncompressed size, set by all
+/// mainstream OSM writers) we can decompress in a single shot into an
+/// exact-sized buffer with libdeflate, which is significantly faster than
+/// streaming inflate. Fall back to streaming flate2 when `raw_size` is
+/// missing or inconsistent.
+fn decompress_zlib(bytes: &Bytes, raw_size: Option<i32>) -> Result<Vec<u8>> {
+    if let Some(raw_size) = raw_size {
+        let size = raw_size as u64;
+        if size >= MAX_BLOB_MESSAGE_SIZE {
+            return Err(new_blob_error(BlobError::MessageTooBig { size }));
+        }
+        let mut decoded_bytes = vec![0u8; raw_size as usize];
+        let mut decompressor = libdeflater::Decompressor::new();
+        match decompressor.zlib_decompress(bytes, &mut decoded_bytes) {
+            Ok(len) if len == decoded_bytes.len() => return Ok(decoded_bytes),
+            // raw_size mismatch: fall through to the streaming path
+            _ => {}
+        }
+    }
+    let mut decoder = ZlibDecoder::new(&**bytes).take(MAX_BLOB_MESSAGE_SIZE);
+    let mut decoded_bytes = Vec::with_capacity(bytes.len() * 3);
+    decoder.read_to_end(&mut decoded_bytes)?;
+    Ok(decoded_bytes)
 }
 
 #[cfg(test)]

--- a/osmpbf/src/block.rs
+++ b/osmpbf/src/block.rs
@@ -428,8 +428,14 @@ pub(crate) fn str_from_stringtable(
     index: usize,
 ) -> Result<&str> {
     if let Some(vec) = block.stringtable.s.get(index) {
-        std::str::from_utf8(vec)
-            .map_err(|e| new_error(ErrorKind::StringtableUtf8 { err: e, index }))
+        // SIMD-accelerated validation; on the (exceptional) error path,
+        // re-validate with std to produce the std Utf8Error the API exposes.
+        simdutf8::basic::from_utf8(vec).map_err(|_| {
+            match std::str::from_utf8(vec) {
+                Err(err) => new_error(ErrorKind::StringtableUtf8 { err, index }),
+                Ok(_) => unreachable!("simdutf8 and std::str::from_utf8 disagree"),
+            }
+        })
     } else {
         Err(new_error(ErrorKind::StringtableIndexOutOfBounds { index }))
     }

--- a/osmpbf/src/block.rs
+++ b/osmpbf/src/block.rs
@@ -430,12 +430,14 @@ pub(crate) fn str_from_stringtable(
     if let Some(vec) = block.stringtable.s.get(index) {
         // SIMD-accelerated validation; on the (exceptional) error path,
         // re-validate with std to produce the std Utf8Error the API exposes.
-        simdutf8::basic::from_utf8(vec).map_err(|_| {
-            match std::str::from_utf8(vec) {
-                Err(err) => new_error(ErrorKind::StringtableUtf8 { err, index }),
-                Ok(_) => unreachable!("simdutf8 and std::str::from_utf8 disagree"),
-            }
-        })
+        // If the validators ever disagree, trust std rather than panic.
+        match simdutf8::basic::from_utf8(vec) {
+            Ok(s) => Ok(s),
+            Err(_) => match std::str::from_utf8(vec) {
+                Ok(s) => Ok(s),
+                Err(err) => Err(new_error(ErrorKind::StringtableUtf8 { err, index })),
+            },
+        }
     } else {
         Err(new_error(ErrorKind::StringtableIndexOutOfBounds { index }))
     }


### PR DESCRIPTION
Last of the four PRs for #28 — decode path in the vendored osmpbf crate.

- One-shot zlib inflate via libdeflater, sized exactly by `Blob.raw_size` (flate2 streaming fallback retained for blobs that don't declare it).
- Zero-copy async blob reads (`BytesMut` + `parse_from_tokio_bytes`).
- simdutf8 for stringtable validation (NEON on aarch64).
- Since these deps are arch-sensitive, adds an arm64 build + unit test CI job on the free `ubuntu-24.04-arm` runner — previously nothing compiled for arm64 before the release cross-build.
- README benchmark section refreshed with current planet numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- retrigger title validation -->