### PR TITLE
[CHORE] Add a reproducible multi-tool benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ osm-pbf-parquet prioritizes transcode speed over file size, file count or preser
 On the 2026-02-02 OSM planet PBF (91GB, 11.58B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m18s** (4,580s CPU, 184GB output).
 
 Comparison against other PBF→parquet paths on the same machine and planet file,
-each pinned to the same 8 performance cores, with outputs verified equivalent
-via aggregate checksums:
+each pinned to the same 8 performance cores and writing zstd level-3 parquet,
+with outputs verified equivalent via aggregate checksums:
 
 | | Wall time | CPU time | Output size | Files |
 | - | - | - | - | - |
-| **osm-pbf-parquet** (zstd:3) | 12m04s | 4,517s | 184GB | 1,083 |
+| **osm-pbf-parquet** | 12m04s | 4,517s | 184GB | 1,083 |
 | [DuckDB](https://duckdb.org) 1.2 spatial `ST_ReadOSM` | 16m28s | 7,330s | 176GB¹ | 3 |
 | [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark) | 60m28s | —² | 204GB | 1,366 |
 

--- a/README.md
+++ b/README.md
@@ -87,24 +87,21 @@ SELECT * FROM osm LIMIT 10;
 ## Benchmarks
 osm-pbf-parquet prioritizes transcode speed over file size, file count or preserving ordering.
 
-On the 2026-02-02 OSM planet PBF (91GB, 11.58B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m18s** (4,580s CPU, 184GB output).
+On the 2026-08-03 OSM planet PBF (94GB, 12.0B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m45s** (4,602s CPU, 193GB output).
 
 Comparison against other PBF→parquet paths on the same machine and planet file,
 each pinned to the same 8 performance cores and writing zstd level-3 parquet,
-with outputs verified equivalent via aggregate checksums:
+with outputs verified equivalent via aggregate checksums. CPU time and peak
+memory are measured from a per-tool cgroup, so they include all child
+processes:
 
-| | Wall time | CPU time | Output size | Files |
-| - | - | - | - | - |
-| **osm-pbf-parquet** | 12m04s | 4,517s | 184GB | 1,083 |
-| [DuckDB](https://duckdb.org) 1.2 spatial `ST_ReadOSM` | 16m28s | 7,330s | 176GB¹ | 3 |
-| [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark) | 60m28s | —² | 204GB | 1,366 |
+| | Wall time | CPU time | Peak memory | Output size | Files |
+| - | - | - | - | - | - |
+| **osm-pbf-parquet** | 11m45s | 4,602s | 8.4GiB | 193GB | 1,682 |
+| [DuckDB](https://duckdb.org) 1.5 spatial `ST_ReadOSM` | 15m40s | 7,018s | 6.3GiB | 195GB¹ | 3 |
+| [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark, pyspark 4.0.1) | 61m16s | 28,625s | 25.5GiB | 227GB | 1,410 |
 
 ¹ `ST_ReadOSM` emits no metadata columns (changeset/timestamp/uid/user/version/visible), so it writes less data per row.
-² Sedona's JVM CPU time is not captured by the harness.
-
-Writing to S3 instead of local disk (North America extract, all tools writing
-to the same MinIO endpoint): osm-pbf-parquet 2m39s wall / 900s CPU,
-DuckDB httpfs 3m31s / 1,591s, Sedona s3a 13m22s.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -89,21 +89,22 @@ osm-pbf-parquet prioritizes transcode speed over file size, file count or preser
 
 On the 2026-02-02 OSM planet PBF (91GB, 11.58B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m18s** (4,580s CPU, 184GB output).
 
-Comparison against similar tools on the 2024-06-24 OSM planet PBF with target file size of 500MB:
-| | Time (wall) | Output size | File count |
-| - | - | - | - |
-| **osm-pbf-parquet** (zstd:3) | 30 minutes | 182GB | ~600 |
-| **osm-pbf-parquet** (zstd:9) | 60 minutes | 165GB | ~600 |
-| [osm-parquetizer](https://github.com/adrianulbona/osm-parquetizer) | 196 minutes | 285GB | 3 |
-| [osm2orc](https://github.com/mojodna/osm2orc) | 385 minutes | 110GB | 1 |
+Comparison against other PBF→parquet paths on the same machine and planet file,
+each pinned to the same 8 performance cores, with outputs verified equivalent
+via aggregate checksums:
 
-Test system:
-```
-i5-9400 (6 CPU, 32GB memory)
-Ubuntu 24.04
-OpenJDK 17
-Rust 1.79.0
-```
+| | Wall time | CPU time | Output size | Files |
+| - | - | - | - | - |
+| **osm-pbf-parquet** (zstd:3) | 12m04s | 4,517s | 184GB | 1,083 |
+| [DuckDB](https://duckdb.org) 1.2 spatial `ST_ReadOSM` | 16m28s | 7,330s | 176GB¹ | 3 |
+| [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark) | 60m28s | —² | 204GB | 1,366 |
+
+¹ `ST_ReadOSM` emits no metadata columns (changeset/timestamp/uid/user/version/visible), so it writes less data per row.
+² Sedona's JVM CPU time is not captured by the harness.
+
+Writing to S3 instead of local disk (North America extract, all tools writing
+to the same MinIO endpoint): osm-pbf-parquet 2m39s wall / 900s CPU,
+DuckDB httpfs 3m31s / 1,591s, Sedona s3a 13m22s.
 
 
 ## License

--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,2 @@
+config.env
+results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -52,6 +52,33 @@ order-independent row fingerprint instead:
 `SELECT count(*), sum(hash(t)) FROM read_parquet('.../type=way/*.parquet') t`
 per type on both sides.
 
+## S3 output variants (MinIO)
+
+`bench/tools/duckdb-s3.sh` and `bench/tools/sedona-s3.sh` mirror the local
+wrappers but write to S3 instead of a local directory. Both take
+`<input.osm.pbf> <s3://bucket/prefix> <workers>` and assume a local MinIO
+server is already running: endpoint `http://127.0.0.1:9102`, path-style
+addressing, no SSL, access key `bench` / secret `benchsecret123`, region
+`us-east-1`, bucket `bench`. Override via `BENCH_S3_ENDPOINT`,
+`BENCH_S3_ACCESS_KEY`, `BENCH_S3_SECRET_KEY`, `BENCH_S3_REGION`.
+
+- DuckDB uses the `httpfs` extension plus a `CREATE SECRET`; COPY options
+  (zstd-3 parquet, `PARTITION_BY (kind)`) match the local variant. DuckDB
+  errors if the target prefix already holds files — clear it before
+  re-running (`mc rm -r --force ...`).
+- Sedona rewrites `s3://` to `s3a://` and `sedona_job.py` then adds
+  `org.apache.hadoop:hadoop-aws:3.4.1` (matching pyspark 4.0.1's Hadoop
+  3.4.x) and the `fs.s3a.*` MinIO confs; local output paths are unaffected.
+  The first S3 run fetches hadoop-aws + the AWS SDK bundle via ivy. Spark's
+  default rename-based output commit is slow on S3 — fine for smoke tests,
+  but consider the S3A magic committer before treating S3 wall times as
+  benchmark numbers.
+
+These wrappers are for direct invocation only: `run.sh` assumes a local
+output directory (`mkdir`/`rm -rf`, `du`/`find` for output size and file
+count, and block-device mapping for iostat), so `--tools duckdb-s3` would
+hand the wrapper a local path and fail fast.
+
 ## Interpreting results
 
 - With input and output on separate disks, all four tools are CPU-bound on

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,61 @@
+# OSM transcode benchmark suite
+
+Reproducible comparison of OSM PBF -> columnar transcode tools:
+osm-pbf-parquet (this repo), DuckDB `ST_ReadOSM`, osm-parquetizer, osm2orc.
+
+## Setup
+
+1. `cp bench/config.env.example bench/config.env` and set tool paths.
+   - DuckDB CLI: https://duckdb.org/docs/installation (spatial extension
+     auto-installs on first run)
+   - osm-parquetizer: clone https://github.com/adrianulbona/osm-parquetizer,
+     `mvn package -DskipTests` (JDK 17)
+   - osm2orc: clone https://github.com/mojodna/osm2orc, `./gradlew installDist`
+2. Pick an input PBF (Geofabrik extract for quick runs, planet for the real
+   numbers) and an output directory — ideally on a different physical disk
+   than the input so read and write I/O don't contend.
+
+## Run
+
+```bash
+bench/run.sh \
+  --input /data/planet.osm.pbf \
+  --output /scratch/osm-bench \
+  --tools osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc \
+  --workers 8 --nice 10 --label planet-2026-02 \
+  --validate
+```
+
+- `--workers` caps threads for tools that support it (osm-pbf-parquet,
+  DuckDB). The Java tools use their own internal threading.
+- `--nice` niceness for every tool run (default 10), so benchmarks coexist
+  with other work on the machine.
+- Results land in `bench/results/<label>/`: per-tool `time -v` logs,
+  iostat samples for the input and output devices, `summary.tsv`
+  (wall / user / sys / CPU% / max RSS / output bytes / file count /
+  avg read and write MB/s), and `validation.txt` with `--validate`.
+
+## Accuracy comparison (`--validate` or `bench/validate.py`)
+
+Medium-weight, schema-aware aggregate validation: per element type it
+compares row counts, id sums, tag-entry counts, way ref counts/sums,
+relation member counts/ref sums/role lengths, and metadata sums (uid,
+changeset) against a reference tool (default osm-pbf-parquet). Columns a
+tool cannot produce are reported `N/A`, not failed — notably DuckDB's
+`ST_ReadOSM` omits all element metadata (changeset, timestamp, uid, user,
+version, visible).
+
+It catches missing/duplicated/corrupted rows and values with high
+probability, at a fraction of the cost of a row-by-row join. For a
+full-pass equivalence check between two *same-schema* outputs, use an
+order-independent row fingerprint instead:
+`SELECT count(*), sum(hash(t)) FROM read_parquet('.../type=way/*.parquet') t`
+per type on both sides.
+
+## Interpreting results
+
+- With input and output on separate disks, all four tools are CPU-bound on
+  modern SSD/NVMe hardware; user+sys CPU seconds is the most transferable
+  metric, wall time is what you experience at a given worker count.
+- Output sizes are not directly comparable across tools: schemas differ
+  (see above), as do container defaults (row-group size, compression).

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,7 +1,8 @@
 # OSM transcode benchmark suite
 
 Reproducible comparison of OSM PBF -> columnar transcode tools:
-osm-pbf-parquet (this repo), DuckDB `ST_ReadOSM`, osm-parquetizer, osm2orc.
+osm-pbf-parquet (this repo), DuckDB `ST_ReadOSM`, Apache Sedona
+(single-node Spark, via `uv`), osm-parquetizer, osm2orc.
 
 ## Setup
 
@@ -30,6 +31,8 @@ bench/run.sh \
   DuckDB). The Java tools use their own internal threading.
 - `--nice` niceness for every tool run (default 10), so benchmarks coexist
   with other work on the machine.
+- `--cpuset` pins every tool to the given cores (taskset syntax, e.g.
+  `0-7`); the JVM tools also get a matching `ActiveProcessorCount`.
 - Results land in `bench/results/<label>/`: per-tool `time -v` logs,
   iostat samples for the input and output devices, `summary.tsv`
   (wall / user / sys / CPU% / max RSS / output bytes / file count /
@@ -43,7 +46,8 @@ relation member counts/ref sums/role lengths, and metadata sums (uid,
 changeset) against a reference tool (default osm-pbf-parquet). Columns a
 tool cannot produce are reported `N/A`, not failed — notably DuckDB's
 `ST_ReadOSM` omits all element metadata (changeset, timestamp, uid, user,
-version, visible).
+version, visible). The osm2orc adapter reads its single ORC file fully
+into memory, so validate that tool at extract scale only.
 
 It catches missing/duplicated/corrupted rows and values with high
 probability, at a fraction of the cost of a row-by-row join. For a

--- a/bench/config.env.example
+++ b/bench/config.env.example
@@ -1,0 +1,12 @@
+# Copy to bench/config.env and adjust. Sourced by bench/run.sh.
+
+# Prebuilt osm-pbf-parquet binary; leave unset to cargo-build from this repo
+#export OSM_PBF_PARQUET_BIN=/path/to/osm-pbf-parquet
+
+# DuckDB CLI (needs the spatial extension installable)
+#export DUCKDB_BIN=$HOME/.duckdb/cli/latest/duckdb
+
+# Java toolchain for osm-parquetizer / osm2orc
+#export JAVA_HOME=$HOME/dev/bench-tools/jdk-17.0.20+8
+#export PARQUETIZER_JAR=$HOME/dev/bench-tools/osm-parquetizer/target/osm-parquetizer-1.0.1-SNAPSHOT.jar
+#export OSM2ORC_BIN=$HOME/dev/bench-tools/osm2orc/build/install/osm2orc/bin/osm2orc

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -79,10 +79,43 @@ for tool in ${TOOLS//,/ }; do
 
     TASKSET=()
     [[ -n "$CPUSET" ]] && TASKSET=(taskset -c "$CPUSET")
+    # Run inside a fresh cgroup so CPU is counted even for children that
+    # exit unreaped (py4j kills the Spark JVM before wait(), so rusage
+    # from /usr/bin/time misses all of Sedona's JVM time)
+    CG="/sys/fs/cgroup/user.slice/user-$(id -u).slice/user@$(id -u).service/bench-$tool-$$"
+    mkdir "$CG" 2>/dev/null || CG=""
+    # Poll peak anonymous memory from the cgroup (RSS-equivalent, excludes
+    # page cache) — rusage max_rss misses unreaped children like Sedona's JVM
+    MEMPOLL_PID=""
+    if [[ -n "$CG" ]]; then
+        rm -f "$RESULTS/$tool.peak_anon"
+        (
+            m=0
+            while [[ -e "$CG/memory.stat" ]]; do
+                a=$(awk '$1=="anon" {print $2}' "$CG/memory.stat" 2>/dev/null)
+                if [[ -n "${a:-}" && "$a" -gt "$m" ]]; then
+                    m=$a
+                    echo "$m" > "$RESULTS/$tool.peak_anon"
+                fi
+                sleep 2
+            done
+        ) &
+        MEMPOLL_PID=$!
+    fi
     set +e
-    /usr/bin/time -v "${TASKSET[@]}" nice -n "$NICENESS" \
-        "$wrapper" "$INPUT" "$outdir" "$WORKERS" > "$RESULTS/$tool.log" 2>&1
+    (
+        [[ -n "$CG" ]] && echo $BASHPID > "$CG/cgroup.procs"
+        exec /usr/bin/time -v "${TASKSET[@]}" nice -n "$NICENESS" \
+            "$wrapper" "$INPUT" "$outdir" "$WORKERS" > "$RESULTS/$tool.log" 2>&1
+    )
     rc=$?
+    cg_user="" cg_sys=""
+    if [[ -n "$CG" ]]; then
+        cg_user=$(awk '$1=="user_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
+        cg_sys=$(awk '$1=="system_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
+        for _ in 1 2 3 4 5; do rmdir "$CG" 2>/dev/null && break; sleep 0.5; done
+    fi
+    [[ -n "$MEMPOLL_PID" ]] && { wait "$MEMPOLL_PID" 2>/dev/null || true; }
     set -e
     kill "$IOSTAT_PID" 2>/dev/null || true
     wait "$IOSTAT_PID" 2>/dev/null || true
@@ -94,10 +127,21 @@ for tool in ${TOOLS//,/ }; do
     fi
 
     wall=$(hms_to_s "$(extract_time_stat "$RESULTS/$tool.log" 'Elapsed (wall clock)')")
-    user=$(extract_time_stat "$RESULTS/$tool.log" 'User time (seconds)')
-    sys=$(extract_time_stat "$RESULTS/$tool.log" 'System time (seconds)')
-    cpu=$(extract_time_stat "$RESULTS/$tool.log" 'Percent of CPU' | tr -d '%')
+    # Prefer cgroup accounting (captures unreaped children); rusage fallback
+    user=${cg_user:-$(extract_time_stat "$RESULTS/$tool.log" 'User time (seconds)')}
+    sys=${cg_sys:-$(extract_time_stat "$RESULTS/$tool.log" 'System time (seconds)')}
+    if [[ -n "$cg_user" ]]; then
+        cpu=$(awk -v u="$cg_user" -v s="$cg_sys" -v w="$wall" 'BEGIN {printf "%.0f", (u+s)*100/w}')
+    else
+        cpu=$(extract_time_stat "$RESULTS/$tool.log" 'Percent of CPU' | tr -d '%')
+    fi
     rss_kb=$(extract_time_stat "$RESULTS/$tool.log" 'Maximum resident set size')
+    # Prefer cgroup peak-anon when it exceeds rusage (unreaped-children case);
+    # take the max since the 2s poller can undersample short spikes
+    if [[ -s "$RESULTS/$tool.peak_anon" ]]; then
+        cg_anon_kb=$(( $(cat "$RESULTS/$tool.peak_anon") / 1024 ))
+        [[ $cg_anon_kb -gt ${rss_kb:-0} ]] && rss_kb=$cg_anon_kb
+    fi
     out_bytes=$(du -sb "$outdir" | cut -f1)
     out_files=$(find "$outdir" -type f | wc -l)
     # iostat: column 3 is rkB/s, column 9 is wkB/s (sysstat 12.x -x layout)

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Multi-tool OSM PBF transcode benchmark driver.
+#
+# Usage:
+#   bench/run.sh --input /path/to/x.osm.pbf --output /scratch/bench-out \
+#       [--tools osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc] \
+#       [--workers 8] [--nice 10] [--label mylabel] [--validate]
+#
+# Tool locations are read from bench/config.env (see config.env.example).
+# Results land in bench/results/<label>/: per-tool time+iostat logs and
+# summary.tsv. Each tool writes to <output>/<tool>/.
+set -euo pipefail
+
+BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS="osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc"
+WORKERS=8
+NICENESS=10
+LABEL="$(date +%Y%m%d-%H%M%S)"
+INPUT="" OUTPUT="" VALIDATE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --input) INPUT="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --tools) TOOLS="$2"; shift 2 ;;
+        --workers) WORKERS="$2"; shift 2 ;;
+        --nice) NICENESS="$2"; shift 2 ;;
+        --label) LABEL="$2"; shift 2 ;;
+        --validate) VALIDATE=1; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$INPUT" && -n "$OUTPUT" ]] || { echo "--input and --output are required" >&2; exit 2; }
+[[ -f "$INPUT" ]] || { echo "input not found: $INPUT" >&2; exit 2; }
+
+[[ -f "$BENCH_DIR/config.env" ]] && source "$BENCH_DIR/config.env"
+
+RESULTS="$BENCH_DIR/results/$LABEL"
+mkdir -p "$RESULTS" "$OUTPUT"
+
+# Map a path to its parent block device for iostat (resolves partitions and
+# LVM/dm to the physical parent where possible).
+device_for_path() {
+    local src dev
+    src=$(df -P "$1" | awk 'NR==2 {print $1}')
+    dev=$(lsblk -no pkname "$src" 2>/dev/null | head -1)
+    if [[ -z "$dev" ]]; then
+        dev=$(basename "$src")
+    fi
+    echo "$dev"
+}
+
+IN_DEV=$(device_for_path "$(dirname "$INPUT")")
+OUT_DEV=$(device_for_path "$OUTPUT")
+echo "input device: $IN_DEV, output device: $OUT_DEV"
+
+SUMMARY="$RESULTS/summary.tsv"
+echo -e "tool\twall_s\tuser_s\tsys_s\tcpu_pct\tmax_rss_mb\tout_bytes\tout_files\tin_dev_r_mbps\tout_dev_w_mbps" > "$SUMMARY"
+
+extract_time_stat() { # file, label
+    grep -F "$2" "$1" | head -1 | sed 's/.*: //'
+}
+
+hms_to_s() { # h:mm:ss or m:ss.xx -> seconds
+    awk -F: '{ if (NF==3) print $1*3600+$2*60+$3; else print $1*60+$2 }' <<<"$1"
+}
+
+for tool in ${TOOLS//,/ }; do
+    wrapper="$BENCH_DIR/tools/$tool.sh"
+    [[ -x "$wrapper" ]] || { echo "SKIP $tool: no wrapper $wrapper" >&2; continue; }
+    outdir="$OUTPUT/$tool"
+    rm -rf "$outdir"; mkdir -p "$outdir"
+
+    echo "=== $tool (workers=$WORKERS nice=$NICENESS) ==="
+    iostat -x 5 -d "$IN_DEV" "$OUT_DEV" > "$RESULTS/$tool.iostat" 2>&1 &
+    IOSTAT_PID=$!
+
+    set +e
+    /usr/bin/time -v nice -n "$NICENESS" \
+        "$wrapper" "$INPUT" "$outdir" "$WORKERS" > "$RESULTS/$tool.log" 2>&1
+    rc=$?
+    set -e
+    kill "$IOSTAT_PID" 2>/dev/null || true
+    wait "$IOSTAT_PID" 2>/dev/null || true
+
+    if [[ $rc -ne 0 ]]; then
+        echo "FAIL $tool rc=$rc (see $RESULTS/$tool.log)"
+        echo -e "$tool\tFAIL\t-\t-\t-\t-\t-\t-\t-\t-" >> "$SUMMARY"
+        continue
+    fi
+
+    wall=$(hms_to_s "$(extract_time_stat "$RESULTS/$tool.log" 'Elapsed (wall clock)')")
+    user=$(extract_time_stat "$RESULTS/$tool.log" 'User time (seconds)')
+    sys=$(extract_time_stat "$RESULTS/$tool.log" 'System time (seconds)')
+    cpu=$(extract_time_stat "$RESULTS/$tool.log" 'Percent of CPU' | tr -d '%')
+    rss_kb=$(extract_time_stat "$RESULTS/$tool.log" 'Maximum resident set size')
+    out_bytes=$(du -sb "$outdir" | cut -f1)
+    out_files=$(find "$outdir" -type f | wc -l)
+    # iostat: column 3 is rkB/s, column 9 is wkB/s (sysstat 12.x -x layout)
+    in_r=$(awk -v d="$IN_DEV" '$1==d {n++; s+=$3} END {if (n) printf "%.0f", s/n/1024; else print "-"}' "$RESULTS/$tool.iostat")
+    out_w=$(awk -v d="$OUT_DEV" '$1==d {n++; s+=$9} END {if (n) printf "%.0f", s/n/1024; else print "-"}' "$RESULTS/$tool.iostat")
+
+    echo -e "$tool\t$wall\t$user\t$sys\t$cpu\t$((rss_kb / 1024))\t$out_bytes\t$out_files\t$in_r\t$out_w" >> "$SUMMARY"
+    column -t "$SUMMARY" | tail -1
+done
+
+echo
+echo "=== summary ($RESULTS/summary.tsv) ==="
+column -t "$SUMMARY"
+
+if [[ $VALIDATE -eq 1 ]]; then
+    echo
+    echo "=== accuracy comparison ==="
+    "$BENCH_DIR/validate.py" --base "$OUTPUT" --tools "$TOOLS" | tee "$RESULTS/validation.txt"
+fi

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   bench/run.sh --input /path/to/x.osm.pbf --output /scratch/bench-out \
 #       [--tools osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc] \
-#       [--workers 8] [--nice 10] [--label mylabel] [--validate]
+#       [--workers 8] [--nice 10] [--cpuset 0-7] [--label mylabel] [--validate]
 #
 # Tool locations are read from bench/config.env (see config.env.example).
 # Results land in bench/results/<label>/: per-tool time+iostat logs and
@@ -34,8 +34,17 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$INPUT" && -n "$OUTPUT" ]] || { echo "--input and --output are required" >&2; exit 2; }
 [[ -f "$INPUT" ]] || { echo "input not found: $INPUT" >&2; exit 2; }
+# Wrappers resolve paths from other directories (e.g. symlink targets), so
+# a relative --input must be absolutized here
+INPUT="$(realpath "$INPUT")"
 
 [[ -f "$BENCH_DIR/config.env" ]] && source "$BENCH_DIR/config.env"
+
+# Build outside the timed window: with OSM_PBF_PARQUET_BIN unset the wrapper
+# builds from this repo, and a cold cargo build would be charged to the run
+if [[ ",$TOOLS," == *",osm-pbf-parquet,"* && -z "${OSM_PBF_PARQUET_BIN:-}" ]]; then
+    cargo build --release --quiet -p osm-pbf-parquet --manifest-path "$BENCH_DIR/../Cargo.toml"
+fi
 
 RESULTS="$BENCH_DIR/results/$LABEL"
 mkdir -p "$RESULTS" "$OUTPUT"
@@ -74,7 +83,8 @@ for tool in ${TOOLS//,/ }; do
     rm -rf "$outdir"; mkdir -p "$outdir"
 
     echo "=== $tool (workers=$WORKERS nice=$NICENESS) ==="
-    iostat -x 5 -d "$IN_DEV" "$OUT_DEV" > "$RESULTS/$tool.iostat" 2>&1 &
+    # -y skips the since-boot first report, which would bias the averages
+    iostat -y -x 5 -d "$IN_DEV" "$OUT_DEV" > "$RESULTS/$tool.iostat" 2>&1 &
     IOSTAT_PID=$!
 
     TASKSET=()
@@ -87,8 +97,8 @@ for tool in ${TOOLS//,/ }; do
     # Poll peak anonymous memory from the cgroup (RSS-equivalent, excludes
     # page cache) — rusage max_rss misses unreaped children like Sedona's JVM
     MEMPOLL_PID=""
+    rm -f "$RESULTS/$tool.peak_anon" "$RESULTS/$tool.cgroup_failed"
     if [[ -n "$CG" ]]; then
-        rm -f "$RESULTS/$tool.peak_anon"
         (
             m=0
             while [[ -e "$CG/memory.stat" ]]; do
@@ -104,18 +114,35 @@ for tool in ${TOOLS//,/ }; do
     fi
     set +e
     (
-        [[ -n "$CG" ]] && echo $BASHPID > "$CG/cgroup.procs"
+        # Migration can fail even when mkdir succeeded: the kernel also needs
+        # write access to the source/destination common ancestor's
+        # cgroup.procs, which an SSH session scope doesn't have. Record the
+        # failure so the empty cgroup's stats aren't trusted below.
+        if [[ -n "$CG" ]] && ! echo $BASHPID > "$CG/cgroup.procs" 2>/dev/null; then
+            touch "$RESULTS/$tool.cgroup_failed"
+        fi
         exec /usr/bin/time -v "${TASKSET[@]}" nice -n "$NICENESS" \
             "$wrapper" "$INPUT" "$outdir" "$WORKERS" > "$RESULTS/$tool.log" 2>&1
     )
     rc=$?
     cg_user="" cg_sys=""
     if [[ -n "$CG" ]]; then
-        cg_user=$(awk '$1=="user_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
-        cg_sys=$(awk '$1=="system_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
+        if [[ -e "$RESULTS/$tool.cgroup_failed" ]]; then
+            echo "WARN: cgroup migration failed for $tool; CPU and memory fall back to rusage" >&2
+        else
+            cg_user=$(awk '$1=="user_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
+            cg_sys=$(awk '$1=="system_usec" {printf "%.2f", $2/1e6}' "$CG/cpu.stat")
+        fi
         for _ in 1 2 3 4 5; do rmdir "$CG" 2>/dev/null && break; sleep 0.5; done
+        [[ -d "$CG" ]] && echo "WARN: cgroup $CG not removed (processes still inside?)" >&2
     fi
-    [[ -n "$MEMPOLL_PID" ]] && { wait "$MEMPOLL_PID" 2>/dev/null || true; }
+    # Kill the poller rather than waiting out its loop: if the cgroup could
+    # not be removed the loop never ends and a bare wait would hang the run.
+    # The peak file is written incrementally, so killing loses nothing.
+    if [[ -n "$MEMPOLL_PID" ]]; then
+        kill "$MEMPOLL_PID" 2>/dev/null || true
+        wait "$MEMPOLL_PID" 2>/dev/null || true
+    fi
     set -e
     kill "$IOSTAT_PID" 2>/dev/null || true
     wait "$IOSTAT_PID" 2>/dev/null || true

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -15,6 +15,7 @@ BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS="osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc"
 WORKERS=8
 NICENESS=10
+CPUSET=""
 LABEL="$(date +%Y%m%d-%H%M%S)"
 INPUT="" OUTPUT="" VALIDATE=0
 
@@ -25,6 +26,7 @@ while [[ $# -gt 0 ]]; do
         --tools) TOOLS="$2"; shift 2 ;;
         --workers) WORKERS="$2"; shift 2 ;;
         --nice) NICENESS="$2"; shift 2 ;;
+        --cpuset) CPUSET="$2"; shift 2 ;;
         --label) LABEL="$2"; shift 2 ;;
         --validate) VALIDATE=1; shift ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
@@ -75,8 +77,10 @@ for tool in ${TOOLS//,/ }; do
     iostat -x 5 -d "$IN_DEV" "$OUT_DEV" > "$RESULTS/$tool.iostat" 2>&1 &
     IOSTAT_PID=$!
 
+    TASKSET=()
+    [[ -n "$CPUSET" ]] && TASKSET=(taskset -c "$CPUSET")
     set +e
-    /usr/bin/time -v nice -n "$NICENESS" \
+    /usr/bin/time -v "${TASKSET[@]}" nice -n "$NICENESS" \
         "$wrapper" "$INPUT" "$outdir" "$WORKERS" > "$RESULTS/$tool.log" 2>&1
     rc=$?
     set -e

--- a/bench/tools/duckdb-s3.sh
+++ b/bench/tools/duckdb-s3.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Wrapper: DuckDB spatial ST_ReadOSM -> zstd parquet partitioned by kind,
+# written to S3 (local MinIO) via the httpfs extension.
+# Usage: duckdb-s3.sh <input.osm.pbf> <s3://bucket/prefix> <workers>
+# Env: DUCKDB_BIN (default: duckdb on PATH); BENCH_S3_ENDPOINT,
+# BENCH_S3_ACCESS_KEY, BENCH_S3_SECRET_KEY, BENCH_S3_REGION override the
+# MinIO defaults (see bench/README.md). Assumes the endpoint is already up.
+# Note: DuckDB errors if the target prefix already contains files; clear it
+# before re-running (run.sh's rm -rf equivalent, e.g. mc rm -r --force).
+set -euo pipefail
+INPUT="$1"; OUTURL="$2"; WORKERS="$3"
+
+case "$OUTURL" in
+    s3://*) ;;
+    *) echo "output must be an s3:// URL, got: $OUTURL" >&2; exit 2 ;;
+esac
+
+BIN="${DUCKDB_BIN:-duckdb}"
+S3_ENDPOINT="${BENCH_S3_ENDPOINT:-http://127.0.0.1:9102}"
+S3_ENDPOINT="${S3_ENDPOINT#http://}"   # DuckDB ENDPOINT wants host:port
+S3_ACCESS_KEY="${BENCH_S3_ACCESS_KEY:-bench}"
+S3_SECRET_KEY="${BENCH_S3_SECRET_KEY:-benchsecret123}"
+S3_REGION="${BENCH_S3_REGION:-us-east-1}"
+
+exec "$BIN" -c "
+INSTALL spatial; LOAD spatial;
+INSTALL httpfs; LOAD httpfs;
+CREATE SECRET (
+    TYPE s3,
+    KEY_ID '$S3_ACCESS_KEY',
+    SECRET '$S3_SECRET_KEY',
+    REGION '$S3_REGION',
+    ENDPOINT '$S3_ENDPOINT',
+    URL_STYLE 'path',
+    USE_SSL false
+);
+SET threads=$WORKERS; SET memory_limit='24GB'; SET preserve_insertion_order=false;
+COPY (SELECT * FROM ST_ReadOSM('$INPUT'))
+TO '$OUTURL' (FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 3, PARTITION_BY (kind));
+"

--- a/bench/tools/duckdb.sh
+++ b/bench/tools/duckdb.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Wrapper: DuckDB spatial ST_ReadOSM -> zstd parquet partitioned by kind.
+# Env: DUCKDB_BIN (default: duckdb on PATH)
+# Note: ST_ReadOSM omits metadata columns (changeset, timestamp, uid, user,
+# version, visible) — it does less work than the other tools.
+set -euo pipefail
+INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
+
+BIN="${DUCKDB_BIN:-duckdb}"
+exec "$BIN" -c "
+INSTALL spatial; LOAD spatial;
+SET threads=$WORKERS; SET memory_limit='24GB'; SET preserve_insertion_order=false;
+COPY (SELECT * FROM ST_ReadOSM('$INPUT'))
+TO '$OUTDIR' (FORMAT PARQUET, COMPRESSION ZSTD, COMPRESSION_LEVEL 3, PARTITION_BY (kind));
+"

--- a/bench/tools/osm-parquetizer.sh
+++ b/bench/tools/osm-parquetizer.sh
@@ -9,6 +9,8 @@ INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
 
 [[ -n "${PARQUETIZER_JAR:-}" ]] || { echo "PARQUETIZER_JAR not set" >&2; exit 2; }
 JAVA="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+# Cap the JVM's view of the machine (GC/ForkJoin pool sizing) to $WORKERS
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -XX:ActiveProcessorCount=$WORKERS"
 
 ln -sf "$INPUT" "$OUTDIR/input.osm.pbf"
 "$JAVA" -jar "$PARQUETIZER_JAR" "$OUTDIR/input.osm.pbf"

--- a/bench/tools/osm-parquetizer.sh
+++ b/bench/tools/osm-parquetizer.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Wrapper: osm-parquetizer (https://github.com/adrianulbona/osm-parquetizer)
+# Env: JAVA_HOME, PARQUETIZER_JAR (path to shaded osm-parquetizer jar)
+# Writes <input>.node.parquet/.way.parquet/.relation.parquet next to the
+# input, so we run it on a symlink inside OUTDIR. Thread count is not
+# configurable.
+set -euo pipefail
+INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
+
+[[ -n "${PARQUETIZER_JAR:-}" ]] || { echo "PARQUETIZER_JAR not set" >&2; exit 2; }
+JAVA="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+
+ln -sf "$INPUT" "$OUTDIR/input.osm.pbf"
+"$JAVA" -jar "$PARQUETIZER_JAR" "$OUTDIR/input.osm.pbf"
+rm -f "$OUTDIR/input.osm.pbf"

--- a/bench/tools/osm-pbf-parquet.sh
+++ b/bench/tools/osm-pbf-parquet.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Wrapper: osm-pbf-parquet. Env: OSM_PBF_PARQUET_BIN (default: build from this repo)
+set -euo pipefail
+INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
+
+BIN="${OSM_PBF_PARQUET_BIN:-}"
+if [[ -z "$BIN" ]]; then
+    REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    cargo build --release --quiet -p osm-pbf-parquet --manifest-path "$REPO/Cargo.toml"
+    BIN="$REPO/target/release/osm-pbf-parquet"
+fi
+
+exec "$BIN" --input "$INPUT" --output "$OUTDIR" --worker-threads "$WORKERS"

--- a/bench/tools/osm2orc.sh
+++ b/bench/tools/osm2orc.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Wrapper: osm2orc (https://github.com/mojodna/osm2orc)
+# Env: JAVA_HOME, OSM2ORC_BIN (path to build/install/osm2orc/bin/osm2orc)
+# Single ORC output file; thread count is not configurable.
+set -euo pipefail
+INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
+
+[[ -n "${OSM2ORC_BIN:-}" ]] || { echo "OSM2ORC_BIN not set" >&2; exit 2; }
+export JAVA_HOME="${JAVA_HOME:-}"
+exec "$OSM2ORC_BIN" "$INPUT" "$OUTDIR/planet.orc"

--- a/bench/tools/osm2orc.sh
+++ b/bench/tools/osm2orc.sh
@@ -7,4 +7,6 @@ INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
 
 [[ -n "${OSM2ORC_BIN:-}" ]] || { echo "OSM2ORC_BIN not set" >&2; exit 2; }
 export JAVA_HOME="${JAVA_HOME:-}"
+# Cap the JVM's view of the machine (GC/ForkJoin pool sizing) to $WORKERS
+export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -XX:ActiveProcessorCount=$WORKERS"
 exec "$OSM2ORC_BIN" "$INPUT" "$OUTDIR/planet.orc"

--- a/bench/tools/sedona-s3.sh
+++ b/bench/tools/sedona-s3.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Wrapper: Apache Sedona single-node (Spark local mode) osmpbf reader,
+# writing zstd parquet to S3 (local MinIO) via s3a://.
+# Usage: sedona-s3.sh <input.osm.pbf> <s3://bucket/prefix> <workers>
+# (an s3a:// output URL is also accepted; s3:// is rewritten to s3a://)
+# Env: JAVA_HOME; optional SPARK_DRIVER_MEMORY, SEDONA_PACKAGE,
+# HADOOP_AWS_PACKAGE, BENCH_S3_ENDPOINT, BENCH_S3_ACCESS_KEY,
+# BENCH_S3_SECRET_KEY, BENCH_S3_REGION (see bench/README.md).
+# Requires uv (fetches pinned pyspark/sedona on first run; the first S3 run
+# also fetches hadoop-aws + AWS SDK via ivy). Assumes MinIO is already up.
+set -euo pipefail
+INPUT="$1"; OUTURL="$2"; WORKERS="$3"
+
+case "$OUTURL" in
+    s3a://*) ;;
+    s3://*) OUTURL="s3a://${OUTURL#s3://}" ;;
+    *) echo "output must be an s3:// or s3a:// URL, got: $OUTURL" >&2; exit 2 ;;
+esac
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SPARK_LOCAL_DIRS="${SPARK_LOCAL_DIRS:-${TMPDIR:-/tmp}}"
+
+exec uv run --quiet \
+    --with "apache-sedona[spark]==1.9.0" \
+    --with "pyspark==4.0.1" \
+    --with pandas \
+    python "$DIR/sedona_job.py" "$INPUT" "$OUTURL" "$WORKERS"

--- a/bench/tools/sedona.sh
+++ b/bench/tools/sedona.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Wrapper: Apache Sedona single-node (Spark local mode) osmpbf reader.
+# Env: JAVA_HOME; optional SPARK_DRIVER_MEMORY, SEDONA_PACKAGE.
+# Requires uv (fetches pinned pyspark/sedona on first run).
+# Full-metadata schema, directly comparable to osm-pbf-parquet.
+set -euo pipefail
+INPUT="$1"; OUTDIR="$2"; WORKERS="$3"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SPARK_LOCAL_DIRS="${SPARK_LOCAL_DIRS:-${TMPDIR:-/tmp}}"
+
+exec uv run --quiet \
+    --with "apache-sedona[spark]==1.9.0" \
+    --with "pyspark==4.0.1" \
+    --with pandas \
+    python "$DIR/sedona_job.py" "$INPUT" "$OUTDIR" "$WORKERS"

--- a/bench/tools/sedona_job.py
+++ b/bench/tools/sedona_job.py
@@ -1,7 +1,12 @@
 """Sedona single-node OSM PBF -> parquet transcode job.
 
 Usage: sedona_job.py <input.osm.pbf> <outdir> <workers>
-Env: SPARK_DRIVER_MEMORY (default 24g), SEDONA_PACKAGE (maven coordinate)
+<outdir> may be a local path or an s3a:// URL. An s3a:// output adds the
+hadoop-aws package and points fs.s3a at the bench MinIO endpoint
+(defaults below, env-overridable); local output is unchanged.
+Env: SPARK_DRIVER_MEMORY (default 24g), SEDONA_PACKAGE (maven coordinate),
+HADOOP_AWS_PACKAGE, BENCH_S3_ENDPOINT, BENCH_S3_ACCESS_KEY,
+BENCH_S3_SECRET_KEY, BENCH_S3_REGION
 """
 import os
 import sys
@@ -13,18 +18,45 @@ driver_mem = os.environ.get("SPARK_DRIVER_MEMORY", "24g")
 package = os.environ.get(
     "SEDONA_PACKAGE", "org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.0"
 )
+packages = package
+s3a_confs = {}
+if outdir.startswith("s3a://"):
+    # pyspark 4.0.1 bundles Hadoop 3.4.x client jars; hadoop-aws must match.
+    packages += "," + os.environ.get(
+        "HADOOP_AWS_PACKAGE", "org.apache.hadoop:hadoop-aws:3.4.1"
+    )
+    s3a_confs = {
+        "spark.hadoop.fs.s3a.endpoint": os.environ.get(
+            "BENCH_S3_ENDPOINT", "http://127.0.0.1:9102"
+        ),
+        "spark.hadoop.fs.s3a.path.style.access": "true",
+        "spark.hadoop.fs.s3a.access.key": os.environ.get(
+            "BENCH_S3_ACCESS_KEY", "bench"
+        ),
+        "spark.hadoop.fs.s3a.secret.key": os.environ.get(
+            "BENCH_S3_SECRET_KEY", "benchsecret123"
+        ),
+        "spark.hadoop.fs.s3a.connection.ssl.enabled": "false",
+        # AWS SDK v2 (Hadoop 3.4.x) wants an explicit region with a
+        # custom endpoint.
+        "spark.hadoop.fs.s3a.endpoint.region": os.environ.get(
+            "BENCH_S3_REGION", "us-east-1"
+        ),
+    }
 
-config = (
+builder = (
     SedonaContext.builder()
     .master(f"local[{workers}]")
     .config("spark.driver.memory", driver_mem)
-    .config("spark.jars.packages", package)
+    .config("spark.jars.packages", packages)
     .config("spark.sql.parquet.compression.codec", "zstd")
     .config("spark.io.compression.zstd.level", "3")
     .config("parquet.compression.codec.zstd.level", "3")
     .config("spark.local.dir", os.environ.get("SPARK_LOCAL_DIRS", "/tmp"))
-    .getOrCreate()
 )
+for key, value in s3a_confs.items():
+    builder = builder.config(key, value)
+config = builder.getOrCreate()
 sedona = SedonaContext.create(config)
 
 df = sedona.read.format("osmpbf").load(inp)

--- a/bench/tools/sedona_job.py
+++ b/bench/tools/sedona_job.py
@@ -1,0 +1,31 @@
+"""Sedona single-node OSM PBF -> parquet transcode job.
+
+Usage: sedona_job.py <input.osm.pbf> <outdir> <workers>
+Env: SPARK_DRIVER_MEMORY (default 24g), SEDONA_PACKAGE (maven coordinate)
+"""
+import os
+import sys
+
+from sedona.spark import SedonaContext
+
+inp, outdir, workers = sys.argv[1], sys.argv[2], int(sys.argv[3])
+driver_mem = os.environ.get("SPARK_DRIVER_MEMORY", "24g")
+package = os.environ.get(
+    "SEDONA_PACKAGE", "org.apache.sedona:sedona-spark-shaded-4.0_2.13:1.9.0"
+)
+
+config = (
+    SedonaContext.builder()
+    .master(f"local[{workers}]")
+    .config("spark.driver.memory", driver_mem)
+    .config("spark.jars.packages", package)
+    .config("spark.sql.parquet.compression.codec", "zstd")
+    .config("spark.io.compression.zstd.level", "3")
+    .config("parquet.compression.codec.zstd.level", "3")
+    .config("spark.local.dir", os.environ.get("SPARK_LOCAL_DIRS", "/tmp"))
+    .getOrCreate()
+)
+sedona = SedonaContext.create(config)
+
+df = sedona.read.format("osmpbf").load(inp)
+df.write.partitionBy("kind").parquet(outdir, mode="overwrite")

--- a/bench/validate.py
+++ b/bench/validate.py
@@ -159,11 +159,40 @@ def read_osm2orc(con, base):
     return out
 
 
+def read_sedona(con, base):
+    """Layout: kind=node|way|relation partitions (Spark partitionBy), full
+    metadata schema. Ways and relations both use refs; roles in ref_roles."""
+    out = {}
+    for t in ["node", "way", "relation"]:
+        g = os.path.join(base, f"kind={t}", "*.parquet")
+        if not glob.glob(g):
+            out[t] = None
+            continue
+        if t == "node":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(NODE_METRICS, r))
+        elif t == "way":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(refs)),
+                                   sum(list_aggregate(refs, 'sum')), sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(WAY_METRICS, r))
+        else:
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(refs)),
+                                   sum(list_aggregate(refs, 'sum')),
+                                   sum(list_aggregate(list_transform(ref_roles, x -> length(coalesce(x,''))), 'sum')),
+                                   sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(REL_METRICS, r))
+    return out
+
+
 ADAPTERS = {
     "osm-pbf-parquet": read_osm_pbf_parquet,
     "duckdb": read_duckdb,
     "osm-parquetizer": read_osm_parquetizer,
     "osm2orc": read_osm2orc,
+    "sedona": read_sedona,
 }
 
 
@@ -223,6 +252,7 @@ def main():
     print("- duckdb (ST_ReadOSM): no changeset/timestamp/uid/user/version/visible; member types via ref_types")
     print("- osm-parquetizer: user as dictionary id (user_sid), lat/lon as latitude/longitude; no visible")
     print("- osm2orc: full schema in a single ORC file")
+    print("- sedona (osmpbf source): full metadata schema; location struct for lat/lon; member types via ref_types")
     sys.exit(exit_code)
 
 

--- a/bench/validate.py
+++ b/bench/validate.py
@@ -238,7 +238,10 @@ def main():
                     row.append("N/A")
                 elif tool == ref:
                     row.append(str(v))
-                elif ref_v is not None and v == ref_v:
+                elif ref_v is None:
+                    # reference lacks this metric; report, don't fail
+                    row.append(f"no-ref({v})")
+                elif v == ref_v:
                     row.append("match")
                 else:
                     row.append(f"MISMATCH({v})")

--- a/bench/validate.py
+++ b/bench/validate.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["duckdb", "pyarrow"]
+# ///
+"""Medium-weight accuracy comparison across OSM transcode tool outputs.
+
+Computes per-element-type aggregates (counts, id sums, tag/ref/member
+aggregates) for each tool's output, normalizing over schema differences,
+and diffs everything against a reference tool (default: osm-pbf-parquet).
+
+This is aggregate-level validation: it will catch missing/extra/corrupted
+rows and values with very high probability, but it is not a row-by-row
+join. Schema gaps (columns a tool simply does not produce) are reported
+as N/A rather than mismatches — e.g. DuckDB's ST_ReadOSM omits changeset,
+timestamp, uid, user, version and visible.
+"""
+import argparse
+import glob
+import os
+import sys
+
+import duckdb
+
+# Metrics per type. Each tool adapter returns {metric_name: value | None}.
+NODE_METRICS = ["count", "sum_id", "tag_entries", "sum_uid", "sum_changeset"]
+WAY_METRICS = ["count", "sum_id", "tag_entries", "refs_count", "refs_sum", "sum_uid", "sum_changeset"]
+REL_METRICS = ["count", "sum_id", "tag_entries", "members_count", "members_ref_sum", "roles_len_sum", "sum_uid", "sum_changeset"]
+
+
+def q1(con, sql):
+    return con.execute(sql).fetchone()
+
+
+def read_osm_pbf_parquet(con, base):
+    """Layout: type=node|way|relation partitions, full schema."""
+    out = {}
+    for t in ["node", "way", "relation"]:
+        g = os.path.join(base, f"type={t}", "*.parquet")
+        if not glob.glob(g):
+            out[t] = None
+            continue
+        if t == "node":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(NODE_METRICS, r))
+        elif t == "way":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(nds)),
+                                   sum(list_aggregate(list_transform(nds, x -> x.ref), 'sum')),
+                                   sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(WAY_METRICS, r))
+        else:
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(members)),
+                                   sum(list_aggregate(list_transform(members, m -> m.ref), 'sum')),
+                                   sum(list_aggregate(list_transform(members, m -> length(coalesce(m.role,''))), 'sum')),
+                                   sum(uid), sum(changeset)
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(REL_METRICS, r))
+    return out
+
+
+def read_duckdb(con, base):
+    """Layout: kind=node|way|relation partitions from ST_ReadOSM.
+    No metadata columns; ways and relations both use refs/ref_roles."""
+    out = {}
+    for t, kind in [("node", "node"), ("way", "way"), ("relation", "relation")]:
+        g = os.path.join(base, f"kind={kind}", "*.parquet")
+        if not glob.glob(g):
+            out[t] = None
+            continue
+        if t == "node":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags))
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(NODE_METRICS, list(r) + [None, None]))
+        elif t == "way":
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(refs)),
+                                   sum(list_aggregate(refs, 'sum'))
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(WAY_METRICS, list(r) + [None, None]))
+        else:
+            r = q1(con, f"""SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(refs)),
+                                   sum(list_aggregate(refs, 'sum')),
+                                   sum(list_aggregate(list_transform(ref_roles, x -> length(coalesce(x,''))), 'sum'))
+                            FROM read_parquet('{g}')""")
+            out[t] = dict(zip(REL_METRICS, list(r) + [None, None]))
+    return out
+
+
+def read_osm_parquetizer(con, base):
+    """Layout: input.osm.pbf.node.parquet / .way.parquet / .relation.parquet.
+    Schema (osm-parquetizer): nodes(id, version, timestamp, changeset, uid,
+    user_sid, tags list<struct<key,value>>, latitude, longitude), ways(...,
+    nodes list<struct<index,nodeId>>), relations(..., members
+    list<struct<id,role,type>>)."""
+    out = {}
+    def find(suffix):
+        m = glob.glob(os.path.join(base, f"*.{suffix}.parquet"))
+        return m[0] if m else None
+
+    f = find("node")
+    if f:
+        r = q1(con, f"""SELECT count(*), sum(id), sum(len(tags)), sum(uid), sum(changeset)
+                        FROM read_parquet('{f}')""")
+        out["node"] = dict(zip(NODE_METRICS, r))
+    else:
+        out["node"] = None
+    f = find("way")
+    if f:
+        r = q1(con, f"""SELECT count(*), sum(id), sum(len(tags)), sum(len(nodes)),
+                               sum(list_aggregate(list_transform(nodes, x -> x.nodeId), 'sum')),
+                               sum(uid), sum(changeset)
+                        FROM read_parquet('{f}')""")
+        out["way"] = dict(zip(WAY_METRICS, r))
+    else:
+        out["way"] = None
+    f = find("relation")
+    if f:
+        r = q1(con, f"""SELECT count(*), sum(id), sum(len(tags)), sum(len(members)),
+                               sum(list_aggregate(list_transform(members, m -> m.id), 'sum')),
+                               sum(list_aggregate(list_transform(members, m -> length(coalesce(m.role,''))), 'sum')),
+                               sum(uid), sum(changeset)
+                        FROM read_parquet('{f}')""")
+        out["relation"] = dict(zip(REL_METRICS, r))
+    else:
+        out["relation"] = None
+    return out
+
+
+def read_osm2orc(con, base):
+    """Layout: single .orc file, osm2orc schema: type partition column absent;
+    columns include id, type ('node'/'way'/'relation'), tags map, nds
+    array<struct<ref>>, members array<struct<type,ref,role>>, changeset,
+    timestamp, uid, user, version, visible. Read via pyarrow (duckdb has no
+    ORC reader) and aggregate in duckdb over arrow batches."""
+    import pyarrow.orc as orc  # noqa: deferred heavy import
+
+    files = glob.glob(os.path.join(base, "*.orc"))
+    if not files:
+        return {"node": None, "way": None, "relation": None}
+    t = orc.ORCFile(files[0]).read()
+    con.register("orc_tbl", t)
+    out = {}
+    r = q1(con, """SELECT count(*), sum(id), sum(cardinality(tags)), sum(uid), sum(changeset)
+                   FROM orc_tbl WHERE type='node'""")
+    out["node"] = dict(zip(NODE_METRICS, r))
+    r = q1(con, """SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(nds)),
+                          sum(list_aggregate(list_transform(nds, x -> x.ref), 'sum')),
+                          sum(uid), sum(changeset)
+                   FROM orc_tbl WHERE type='way'""")
+    out["way"] = dict(zip(WAY_METRICS, r))
+    r = q1(con, """SELECT count(*), sum(id), sum(cardinality(tags)), sum(len(members)),
+                          sum(list_aggregate(list_transform(members, m -> m.ref), 'sum')),
+                          sum(list_aggregate(list_transform(members, m -> length(coalesce(m.role,''))), 'sum')),
+                          sum(uid), sum(changeset)
+                   FROM orc_tbl WHERE type='relation'""")
+    out["relation"] = dict(zip(REL_METRICS, r))
+    con.unregister("orc_tbl")
+    return out
+
+
+ADAPTERS = {
+    "osm-pbf-parquet": read_osm_pbf_parquet,
+    "duckdb": read_duckdb,
+    "osm-parquetizer": read_osm_parquetizer,
+    "osm2orc": read_osm2orc,
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="dir containing per-tool output subdirs")
+    ap.add_argument("--tools", default="osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc")
+    ap.add_argument("--reference", default="osm-pbf-parquet")
+    ap.add_argument("--threads", type=int, default=6)
+    args = ap.parse_args()
+
+    con = duckdb.connect()
+    con.execute(f"SET threads={args.threads}")
+
+    tools = [t for t in args.tools.split(",") if t]
+    results = {}
+    for tool in tools:
+        base = os.path.join(args.base, tool)
+        if not os.path.isdir(base):
+            print(f"note: no output dir for {tool}, skipping")
+            continue
+        try:
+            results[tool] = ADAPTERS[tool](con, base)
+        except Exception as e:  # surface but keep comparing other tools
+            print(f"ERROR reading {tool}: {e}")
+
+    ref = args.reference
+    if ref not in results:
+        print(f"reference tool {ref} has no results; aborting comparison")
+        sys.exit(1)
+
+    exit_code = 0
+    for t, metrics in [("node", NODE_METRICS), ("way", WAY_METRICS), ("relation", REL_METRICS)]:
+        print(f"\n== {t} ==")
+        header = ["metric", *results.keys()]
+        rows = []
+        for m in metrics:
+            row = [m]
+            ref_v = (results[ref].get(t) or {}).get(m)
+            for tool in results:
+                v = (results[tool].get(t) or {}).get(m)
+                if v is None:
+                    row.append("N/A")
+                elif tool == ref:
+                    row.append(str(v))
+                elif ref_v is not None and v == ref_v:
+                    row.append("match")
+                else:
+                    row.append(f"MISMATCH({v})")
+                    exit_code = 1
+            rows.append(row)
+        widths = [max(len(r[i]) for r in [header] + rows) for i in range(len(header))]
+        for r in [header] + rows:
+            print("  ".join(c.ljust(w) for c, w in zip(r, widths)))
+
+    print("\nSchema coverage notes:")
+    print("- duckdb (ST_ReadOSM): no changeset/timestamp/uid/user/version/visible; member types via ref_types")
+    print("- osm-parquetizer: user as dictionary id (user_sid), lat/lon as latitude/longitude; no visible")
+    print("- osm2orc: full schema in a single ORC file")
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fourth PR for #28 — the benchmark harness behind the numbers in the series.

- Reproducible multi-tool driver (`bench/run.sh`): per-tool wrappers for osm-pbf-parquet, DuckDB spatial `ST_ReadOSM`, Apache Sedona (single-node Spark via uv), osm-parquetizer, and osm2orc; pinned cores (`--cpuset`), fixed niceness, iostat capture, and a `summary.tsv` per labeled run.
- CPU time and peak memory are read from a per-tool cgroup, so children that exit unreaped are still counted — `/usr/bin/time` rusage misses Sedona's JVM entirely (py4j kills it before `wait()`).
- Schema-aware aggregate validation (`bench/validate.py`): per element type it compares row counts, id/uid/changeset sums, tag-entry counts, and way-ref / relation-member checksums across tools, tolerant of per-tool schema differences.
- S3 output variants for DuckDB (httpfs) and Sedona (s3a) against a local MinIO endpoint.
- Repo README benchmark section rebuilt from this harness's planet runs: adds a peak-memory column and cites current tool versions (DuckDB 1.5.5, pyspark 4.0.1 / Sedona 1.9).

Everything lives in `bench/` with no impact on the shipped crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)