### PR TITLE
[PERFORMANCE] Rotate parquet files on writer-reported bytes, not the element estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,6 +1657,7 @@ dependencies = [
  "object_store",
  "osmpbf",
  "parquet",
+ "protobuf",
  "sysinfo",
  "thiserror 2.0.19",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ parquet/
     way_0000.zstd.parquet
     ...
 ```
+Files are rolled once the parquet writer has emitted `--file-target-mb`
+(default 500MB), so output files land close to that size.
+
 [Reference Arrow/SQL schema](https://github.com/OvertureMaps/osm-pbf-parquet/blob/main/src/osm_arrow.rs)
 
 ### Querying
@@ -85,23 +88,24 @@ SELECT * FROM osm LIMIT 10;
 
 
 ## Benchmarks
-osm-pbf-parquet prioritizes transcode speed over file size, file count or preserving ordering.
+osm-pbf-parquet prioritizes transcode speed over preserving element ordering.
 
-On the 2026-08-03 OSM planet PBF (94GB, 12.0B elements) with zstd:3 and 8 worker threads (Core Ultra 7 265K, 64GB, input on NVMe, output on a separate SATA SSD), osm-pbf-parquet transcodes the full planet in **11m45s** (4,602s CPU, 193GB output).
+Measured on the 2026-08-03 OSM planet PBF (94GB, 12.0B elements), transcoded by
+each tool on the same machine (Core Ultra 7 265K, 64GB, input on NVMe, output
+on a separate SATA SSD), pinned to the same 8 performance cores, with 8 worker
+threads and zstd level-3 parquet output, and outputs verified equivalent via
+aggregate checksums. CPU time is user + system time; peak memory includes child
+processes, so Sedona's Spark JVM is counted:
 
-Comparison against other PBF→parquet paths on the same machine and planet file,
-each pinned to the same 8 performance cores and writing zstd level-3 parquet,
-with outputs verified equivalent via aggregate checksums. CPU time and peak
-memory are measured from a per-tool cgroup, so they include all child
-processes:
-
-| | Wall time | CPU time | Peak memory | Output size | Files |
+| | Wall time | CPU time | Peak memory | Output size | Files² |
 | - | - | - | - | - | - |
-| **osm-pbf-parquet** | 11m45s | 4,602s | 8.4GiB | 193GB | 1,682 |
-| [DuckDB](https://duckdb.org) 1.5 spatial `ST_ReadOSM` | 15m40s | 7,018s | 6.3GiB | 195GB¹ | 3 |
-| [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark, pyspark 4.0.1) | 61m16s | 28,625s | 25.5GiB | 227GB | 1,410 |
+| **osm-pbf-parquet** | 11m07s | 4,931s | 7.8GiB | 193GB | 377 |
+| [DuckDB](https://duckdb.org) 1.5 spatial `ST_ReadOSM` | 15m40s | 7,298s | 6.3GiB | 195GB¹ | 3 |
+| [Apache Sedona](https://sedona.apache.org) 1.9 (single-node Spark, pyspark 4.0.1) | 61m16s | 28,884s | 25.5GiB | 227GB | 1,410 |
 
 ¹ `ST_ReadOSM` emits no metadata columns (changeset/timestamp/uid/user/version/visible), so it writes less data per row.
+
+² Only osm-pbf-parquet targets a file size; the others write one file per output partition. See [bench/README.md](bench/README.md).
 
 
 ## License

--- a/osm-pbf-parquet/Cargo.toml
+++ b/osm-pbf-parquet/Cargo.toml
@@ -24,6 +24,8 @@ url = "2.5.8"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["async_futures", "async_tokio"] }
+osmpbf = { workspace = true, features = ["proto"] }
+protobuf = "3.1"
 
 [lib]
 name = "osm_pbf_parquet"

--- a/osm-pbf-parquet/src/sink.rs
+++ b/osm-pbf-parquet/src/sink.rs
@@ -32,7 +32,6 @@ pub struct ElementSink {
 
     // State tracking for batching
     estimated_record_batch_bytes: usize,
-    estimated_file_bytes: usize,
     target_record_batch_bytes: usize,
     target_file_bytes: usize,
     pub last_write_cycle: Instant,
@@ -53,7 +52,6 @@ impl ElementSink {
             closed: false,
 
             estimated_record_batch_bytes: 0usize,
-            estimated_file_bytes: 0usize,
             target_record_batch_bytes: args.get_record_batch_target_bytes(),
             target_file_bytes: args.get_file_target_bytes(),
             last_write_cycle: Instant::now(),
@@ -101,15 +99,19 @@ impl ElementSink {
         writer.write(&batch).await?;
 
         // Close out file if it reached its target size; the next batch
-        // lazily opens a new one
-        self.estimated_file_bytes += self.estimated_record_batch_bytes;
-        if self.estimated_file_bytes >= self.target_file_bytes {
+        // lazily opens a new one. Size comes from the writer itself:
+        // bytes_written() counts what has been flushed to the sink, and
+        // in_progress_size() the encoded size of the row group still
+        // buffered, so the two together track the eventual file size.
+        // The per-element estimate is uncompressed and overshoots by
+        // several x, which capped files well under the target.
+        let file_bytes = writer.bytes_written() + writer.in_progress_size();
+        if file_bytes >= self.target_file_bytes {
             self.writer
                 .take()
                 .ok_or(OsmPbfParquetError::WriterClosed)?
                 .close()
                 .await?;
-            self.estimated_file_bytes = 0;
         }
 
         self.estimated_record_batch_bytes = 0;

--- a/osm-pbf-parquet/tests/common/mod.rs
+++ b/osm-pbf-parquet/tests/common/mod.rs
@@ -1,0 +1,119 @@
+//! Synthetic PBF generation for tests that need more data than the golden
+//! fixtures carry — file rotation, for one, cannot be reached by a 650 byte
+//! fixture at the smallest legal `--file-target-mb`.
+//!
+//! Output is written fresh into `CARGO_TARGET_TMPDIR` on every run, so no
+//! binary fixture is committed and the size is a parameter rather than a
+//! property of a checked-in file.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use osmpbf::{fileformat, osmformat};
+use protobuf::Message;
+
+/// Elements per `PrimitiveBlock`, matching what real PBF writers emit.
+const NODES_PER_BLOCK: u64 = 8000;
+
+/// Deterministic PRNG. Coordinates need genuine entropy: sequential values
+/// would delta-encode to almost nothing, so a compressed run would not
+/// reproduce the estimate-vs-actual size gap that file rotation depends on.
+struct Lcg(u64);
+
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0 >> 16
+    }
+}
+
+/// Writes `node_count` dense nodes with ids `1..=node_count` and pseudo-random
+/// coordinates. Tags and metadata are omitted: `keys_vals` may be empty (the
+/// decoder's tag loop simply yields nothing) and `DenseInfo` is optional.
+///
+/// Returns the path to the generated `.osm.pbf`.
+pub fn write_dense_node_pbf(label: &str, node_count: u64) -> PathBuf {
+    let path = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!("{label}.osm.pbf"));
+    let file = File::create(&path).expect("failed to create fixture");
+    let mut out = BufWriter::new(file);
+
+    write_blob(&mut out, "OSMHeader", header_block());
+    let mut first_id = 1u64;
+    while first_id <= node_count {
+        let count = NODES_PER_BLOCK.min(node_count - first_id + 1);
+        write_blob(&mut out, "OSMData", dense_block(first_id, count));
+        first_id += count;
+    }
+
+    out.flush().expect("failed to flush fixture");
+    path
+}
+
+fn header_block() -> Vec<u8> {
+    let mut block = osmformat::HeaderBlock::new();
+    block.required_features.push("OsmSchema-V0.6".into());
+    block.required_features.push("DenseNodes".into());
+    block
+        .write_to_bytes()
+        .expect("failed to encode HeaderBlock")
+}
+
+fn dense_block(first_id: u64, count: u64) -> Vec<u8> {
+    // Seeded per block so the file is reproducible regardless of block size.
+    let mut rng = Lcg(first_id.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+
+    let mut dense = osmformat::DenseNodes::new();
+    let (mut prev_id, mut prev_lat, mut prev_lon) = (0i64, 0i64, 0i64);
+    for offset in 0..count {
+        let id = (first_id + offset) as i64;
+        // granularity 100 => degrees = value * 1e-7
+        let lat = (rng.next() % 1_700_000_000) as i64 - 850_000_000;
+        let lon = (rng.next() % 3_600_000_000) as i64 - 1_800_000_000;
+
+        dense.id.push(id - prev_id);
+        dense.lat.push(lat - prev_lat);
+        dense.lon.push(lon - prev_lon);
+        (prev_id, prev_lat, prev_lon) = (id, lat, lon);
+    }
+
+    let mut group = osmformat::PrimitiveGroup::new();
+    group.dense = protobuf::MessageField::some(dense);
+
+    // Index 0 of the string table is required to be empty.
+    let mut stringtable = osmformat::StringTable::new();
+    stringtable.s.push(Vec::new().into());
+
+    let mut block = osmformat::PrimitiveBlock::new();
+    block.stringtable = protobuf::MessageField::some(stringtable);
+    block.primitivegroup.push(group);
+    block.set_granularity(100);
+    block
+        .write_to_bytes()
+        .expect("failed to encode PrimitiveBlock")
+}
+
+/// A PBF is a sequence of (big-endian u32 header length, BlobHeader, Blob).
+/// Blobs are written uncompressed via the `raw` field, which the reader
+/// accepts directly.
+fn write_blob<W: Write>(out: &mut W, blob_type: &str, payload: Vec<u8>) {
+    let mut blob = fileformat::Blob::new();
+    blob.set_raw(payload.into());
+    let blob_bytes = blob.write_to_bytes().expect("failed to encode Blob");
+
+    let mut header = fileformat::BlobHeader::new();
+    header.set_type(blob_type.into());
+    header.set_datasize(blob_bytes.len() as i32);
+    let header_bytes = header
+        .write_to_bytes()
+        .expect("failed to encode BlobHeader");
+
+    out.write_all(&(header_bytes.len() as u32).to_be_bytes())
+        .expect("failed to write blob header length");
+    out.write_all(&header_bytes)
+        .expect("failed to write header");
+    out.write_all(&blob_bytes).expect("failed to write blob");
+}

--- a/osm-pbf-parquet/tests/rotation.rs
+++ b/osm-pbf-parquet/tests/rotation.rs
@@ -1,0 +1,236 @@
+//! File rotation round-trip.
+//!
+//! Rotation is the one write path the golden fixtures cannot reach — they are
+//! a few hundred bytes, and the smallest legal `--file-target-mb` is 1. These
+//! tests generate enough synthetic input to cross that boundary several times
+//! and assert nothing is lost or duplicated at the seams.
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int64Type;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+const NODE_COUNT: u64 = 300_000;
+/// Enough that every sink in a multi-worker pool rotates at least once.
+const CONCURRENT_NODE_COUNT: u64 = 900_000;
+const ROW_GROUP_ROWS: &str = "20000";
+
+fn convert(input: &Path, label: &str, workers: u32, extra_args: &[&str]) -> PathBuf {
+    let out_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(label);
+    if out_dir.exists() {
+        std::fs::remove_dir_all(&out_dir).expect("failed to clear output dir");
+    }
+    std::fs::create_dir_all(&out_dir).expect("failed to create output dir");
+
+    let status = Command::new(env!("CARGO_BIN_EXE_osm-pbf-parquet"))
+        .arg("--input")
+        .arg(input)
+        .arg("--output")
+        .arg(&out_dir)
+        .arg("--worker-threads")
+        .arg(workers.to_string())
+        .args(extra_args)
+        .status()
+        .expect("failed to run osm-pbf-parquet binary");
+    assert!(status.success(), "conversion exited with {status}");
+    out_dir
+}
+
+fn node_files(out_dir: &Path) -> Vec<PathBuf> {
+    let type_dir = out_dir.join("type=node");
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(&type_dir)
+        .unwrap_or_else(|e| panic!("missing output dir {}: {e}", type_dir.display()))
+        .map(|entry| entry.expect("failed to read dir entry").path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "parquet"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// Every id read back across all files, in the order encountered. Returned as
+/// a Vec rather than a set so duplicates are still visible to the caller.
+fn collect_ids(paths: &[PathBuf]) -> Vec<i64> {
+    let mut ids = Vec::new();
+    for path in paths {
+        let file = std::fs::File::open(path).expect("failed to open parquet file");
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .expect("failed to open parquet reader")
+            .build()
+            .expect("failed to build parquet reader");
+        for batch in reader {
+            let batch = batch.expect("failed to read batch");
+            let column = batch
+                .column_by_name("id")
+                .expect("missing id column")
+                .as_primitive::<Int64Type>();
+            ids.extend(column.iter().map(|v| v.expect("null id")));
+        }
+    }
+    ids
+}
+
+/// One worker means one sink in the pool, so every file past the first is
+/// necessarily a rotation rather than a second sink writing in parallel.
+#[test]
+fn rotation_preserves_every_row() {
+    let input = common::write_dense_node_pbf("rotation-nodes", NODE_COUNT);
+    let out_dir = convert(
+        &input,
+        "rotation-preserves",
+        1,
+        &[
+            "--compression",
+            "0",
+            "--file-target-mb",
+            "1",
+            "--record-batch-target-mb",
+            "1",
+        ],
+    );
+
+    let paths = node_files(&out_dir);
+    assert!(
+        paths.len() > 1,
+        "expected rotation to produce multiple files, got {}",
+        paths.len()
+    );
+    assert_ids_complete(&paths, NODE_COUNT);
+}
+
+/// The pool holds up to `1.5 * worker_threads` sinks, each owning its own file,
+/// so a file count above that bound is what proves rotation happened rather
+/// than sinks merely running in parallel. Concurrency is where rows would be
+/// lost or duplicated if a rotation raced the writes around it.
+#[test]
+fn concurrent_sinks_preserve_every_row() {
+    const WORKERS: u32 = 4;
+    let max_sinks = (1.5 * WORKERS as f32) as usize;
+
+    let input = common::write_dense_node_pbf("rotation-concurrent-nodes", CONCURRENT_NODE_COUNT);
+    let out_dir = convert(
+        &input,
+        "rotation-concurrent",
+        WORKERS,
+        &[
+            "--compression",
+            "3",
+            "--file-target-mb",
+            "1",
+            "--record-batch-target-mb",
+            "1",
+        ],
+    );
+
+    let paths = node_files(&out_dir);
+    assert!(
+        paths.len() > max_sinks,
+        "got {} files for at most {max_sinks} sinks, so nothing necessarily \
+         rotated — raise CONCURRENT_NODE_COUNT",
+        paths.len()
+    );
+    assert_ids_complete(&paths, CONCURRENT_NODE_COUNT);
+}
+
+/// Ids are generated as `1..=expected`, so a complete, duplicate-free read back
+/// across every output file is exactly that range.
+fn assert_ids_complete(paths: &[PathBuf], expected: u64) {
+    let ids = collect_ids(paths);
+    assert_eq!(
+        ids.len(),
+        expected as usize,
+        "row count across {} files does not match input",
+        paths.len()
+    );
+
+    let unique: BTreeSet<i64> = ids.iter().copied().collect();
+    assert_eq!(unique.len(), ids.len(), "ids duplicated across files");
+    assert_eq!(*unique.first().expect("no ids"), 1);
+    assert_eq!(*unique.last().expect("no ids"), expected as i64);
+}
+
+/// Rotation must be driven by what the writer actually emitted. Accumulating
+/// the per-element size estimate instead closed files several times under
+/// target, which this catches.
+///
+/// Measured on this fixture at a 1MB target: writer-reported bytes land the
+/// rotated files at ~1078KB, the old estimate landed them at ~362KB. The bar
+/// below sits between the two with room for compression to vary.
+#[test]
+fn rotated_files_reach_their_target() {
+    let paths = rotate_at_1mb("rotation-target", &[]);
+    assert_rotated_files_reach_target(&paths);
+}
+
+/// The rotation check sums two terms: bytes already flushed to the sink, and
+/// the encoded size of the row group still buffered. At parquet's default of
+/// ~1M rows per row group these fixtures fit in a single row group, leaving
+/// `bytes_written()` at just the file magic — so the test above only covers
+/// the buffered term. Production runs the opposite regime (~29 row groups per
+/// 500MB file), so cap the row group size here to flush several per file and
+/// put the weight on the flushed term instead.
+#[test]
+fn rotation_accounts_for_flushed_row_groups() {
+    let paths = rotate_at_1mb(
+        "rotation-row-groups",
+        &["--max-row-group-count", ROW_GROUP_ROWS],
+    );
+
+    let row_groups = row_group_count(&paths[0]);
+    assert!(
+        row_groups > 1,
+        "expected several row groups per file, got {row_groups} — this test no \
+         longer covers the flushed-bytes term"
+    );
+
+    assert_rotated_files_reach_target(&paths);
+}
+
+/// `label` also names the fixture: tests run in parallel and `File::create`
+/// truncates, so two of them must not share an input path.
+fn rotate_at_1mb(label: &str, extra: &[&str]) -> Vec<PathBuf> {
+    let input = common::write_dense_node_pbf(&format!("{label}-input"), NODE_COUNT);
+    let mut args = vec![
+        "--compression",
+        "3",
+        "--file-target-mb",
+        "1",
+        "--record-batch-target-mb",
+        "1",
+    ];
+    args.extend_from_slice(extra);
+    let out_dir = convert(&input, label, 1, &args);
+
+    let paths = node_files(&out_dir);
+    assert!(
+        paths.len() > 1,
+        "expected rotation to produce multiple files, got {}",
+        paths.len()
+    );
+    paths
+}
+
+fn assert_rotated_files_reach_target(paths: &[PathBuf]) {
+    // The final file holds whatever remained when input ran out, so only the
+    // rotated ones carry a size guarantee.
+    for path in &paths[..paths.len() - 1] {
+        let size = std::fs::metadata(path).expect("failed to stat file").len();
+        assert!(
+            size >= 768 * 1024,
+            "{} is {size} bytes, well under the 1MB target",
+            path.display()
+        );
+    }
+}
+
+fn row_group_count(path: &Path) -> usize {
+    let file = std::fs::File::open(path).expect("failed to open parquet file");
+    ParquetRecordBatchReaderBuilder::try_new(file)
+        .expect("failed to open parquet reader")
+        .metadata()
+        .num_row_groups()
+}

--- a/osmpbf/Cargo.toml
+++ b/osmpbf/Cargo.toml
@@ -17,6 +17,8 @@ default = ["rust-zlib"]
 rust-zlib = ["flate2/rust_backend"]
 zlib = ["flate2/zlib"]
 zlib-ng = ["flate2/zlib-ng"]
+# Re-export generated protobuf types for building synthetic PBF in tests
+proto = []
 
 [dependencies]
 async-stream = { version = "0.3.6", optional = true }

--- a/osmpbf/src/lib.rs
+++ b/osmpbf/src/lib.rs
@@ -91,6 +91,11 @@ pub mod indexed;
 pub mod mmap_blob;
 pub mod reader;
 
+/// Generated protobuf types, re-exported under the `proto` feature so tests can
+/// build synthetic PBF input. Not part of the stable API.
+#[cfg(feature = "proto")]
+pub use proto::{fileformat, osmformat};
+
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }


### PR DESCRIPTION
File rotation accumulated the per-element size estimate (`64 + tag bytes + 8/ref + 10/member`), which is uncompressed and overshoots by several x, so files closed well under `--file-target-mb`. Now uses the writer's own accounting: `bytes_written()` for what has been flushed, plus `in_progress_size()` for the row group still buffered.

2026-08-03 planet, zstd:3, 8 workers pinned to 8 P-cores, two runs per side:

| | before | after |
| - | - | - |
| Files | 1,685 | 377 |
| Output bytes | 192.93GB | 192.95GB |
| Wall | 705.1s | 669.7s (−5.0%) |
| CPU (user+sys) | 4,928s | 4,931s |

Node files land at 501–535MB against the 500MB target, versus a 115MB median before. Wall time reproduces to ~0.07% between runs of an identical binary, so the 5% is real; peak RSS varies ~9% run-to-run, so I'm not claiming the apparent memory drop.

**Behavior change:** `--file-target-mb` changes meaning — the default 500 previously produced ~119MB files and now produces ~500MB ones, so anyone who raised it to compensate will get proportionally larger files.

**On the rest of #12:** the issue also proposed replacing byte estimation with row-count batching, motivated by a 20.5GB → 6.4GB peak RSS drop. That's superseded — #31 capped the default record batch target at 128MB, which addressed the same blowup (planet now peaks ~7.7GB). Row-count batching would also trade a self-correcting heuristic for one that doesn't adapt to element size variance, which the issue itself flagged. Keeping `--record-batch-target-mb`.

### Tests

Rotation had no coverage: the golden fixtures are a few hundred bytes and the smallest legal `--file-target-mb` is 1, so they cannot reach it. This adds a synthetic PBF generator — built into `CARGO_TARGET_TMPDIR` per run, so nothing is committed and the size is a parameter — and four tests:

| Test | Guards |
| - | - |
| `rotation_preserves_every_row` | no rows lost or duplicated across a rotation, single sink |
| `concurrent_sinks_preserve_every_row` | same with 4 workers; a file count above the `1.5 × workers` sink bound is what proves rotation rather than parallel sinks |
| `rotated_files_reach_their_target` | files reach target, with `in_progress_size()` the dominant term |
| `rotation_accounts_for_flushed_row_groups` | same with row groups capped so `bytes_written()` dominates instead |

The two size tests fail against the previous behavior (371KB files against a 1MB target); the two integrity tests pass. That split is why both are needed — the old code sized files wrong without ever losing data, so integrity checks alone would not have caught this.

The generator needs osmpbf's generated protobuf types, re-exported behind a new `proto` feature. Release builds do not enable it, so the crate's public API is unchanged.

Benchmark harness defects found while measuring this are split out into #36.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)