### PR TITLE
[CHORE] Make benchmark measurements consistently sourced and reproducible

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -36,7 +36,9 @@ bench/run.sh \
 - Results land in `bench/results/<label>/`: per-tool `time -v` logs,
   iostat samples for the input and output devices, `summary.tsv`
   (wall / user / sys / CPU% / max RSS / output bytes / file count /
-  avg read and write MB/s), and `validation.txt` with `--validate`.
+  avg read and write MB/s), `versions.txt` recording the binary each tool
+  actually resolved to and its version, and `validation.txt` with
+  `--validate`.
 
 ## Accuracy comparison (`--validate` or `bench/validate.py`)
 
@@ -90,3 +92,34 @@ hand the wrapper a local path and fail fast.
   metric, wall time is what you experience at a given worker count.
 - Output sizes are not directly comparable across tools: schemas differ
   (see above), as do container defaults (row-group size, compression).
+- File counts are not comparable: only osm-pbf-parquet targets a file size
+  (`--file-target-mb`, default 500MB). DuckDB writes one file per
+  `PARTITION_BY` value, and refuses `FILE_SIZE_BYTES` or `PER_THREAD_OUTPUT`
+  alongside it.
+- Sedona writes one file per Spark partition per key. Read and write are a
+  single stage, so `spark.sql.files.maxPartitionBytes` (128MB default,
+  overridable via `SEDONA_MAX_PARTITION_BYTES`) sets split count, task
+  parallelism and file count together. Raising it to 512MB on the planet gave
+  358 files instead of 1,410, at 5.8% more wall time and 3.4% more CPU: the job
+  already saturates ~96% of 8 cores, so larger tasks only lose on load balance
+  and GC.
+- `summary.tsv` reports `user_s`/`sys_s` separately; the CPU figure quoted in
+  the top-level README is their sum. Peak memory is rusage max RSS,
+  replaced by the cgroup's peak anonymous memory when that is larger — which
+  in practice happens only for Sedona, whose JVM py4j kills before `wait()`.
+- Peak RSS is the noisiest column: repeat runs of an identical binary have
+  differed by ~9%, against ~0.1% for wall time. Do not read small memory
+  deltas as signal.
+
+### cgroup accounting
+
+Per-tool CPU and memory come from a cgroup so unreaped children are counted.
+Creating one is not enough: the kernel also wants write access to the
+`cgroup.procs` of the common ancestor of the source and destination cgroups,
+and a login or SSH session sits in `user-<uid>.slice/session-N.scope` under a
+root-owned parent. `run.sh` therefore re-execs itself in a scope under
+`user@<uid>.service`, which systemd delegates to the invoking user.
+
+Where that is not possible the run still proceeds, logging `WARN: cgroup
+migration failed` and falling back to rusage. A run with working accounting
+leaves `<tool>.peak_anon` and no `<tool>.cgroup_failed` in its results dir.

--- a/bench/config.env.example
+++ b/bench/config.env.example
@@ -3,8 +3,10 @@
 # Prebuilt osm-pbf-parquet binary; leave unset to cargo-build from this repo
 #export OSM_PBF_PARQUET_BIN=/path/to/osm-pbf-parquet
 
-# DuckDB CLI (needs the spatial extension installable)
-#export DUCKDB_BIN=$HOME/.duckdb/cli/latest/duckdb
+# DuckDB CLI (needs the spatial extension installable). Pin an explicit
+# version rather than a "latest" symlink or the PATH default: older CLIs are
+# materially slower, so an unpinned path silently changes what is measured.
+#export DUCKDB_BIN=$HOME/dev/bench-tools/duckdb-1.5.5/duckdb
 
 # Java toolchain for osm-parquetizer / osm2orc
 #export JAVA_HOME=$HOME/dev/bench-tools/jdk-17.0.20+8

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -12,6 +12,20 @@
 set -euo pipefail
 
 BENCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Per-tool cgroup accounting needs write access to the cgroup.procs of the
+# common ancestor of the source and destination cgroups, which a login or SSH
+# session scope does not have; re-exec under user@<uid>.service, which systemd
+# delegates to us (see README.md). The probe separates "no usable user manager"
+# — fall through to the rusage fallback — from a benchmark failure.
+if [[ -z "${BENCH_IN_USER_SCOPE:-}" ]] \
+    && ! grep -qF "user@$(id -u).service" /proc/self/cgroup \
+    && command -v systemd-run >/dev/null 2>&1 \
+    && systemd-run --user --scope --quiet --same-dir -- true 2>/dev/null; then
+    export BENCH_IN_USER_SCOPE=1
+    exec systemd-run --user --scope --quiet --same-dir -- "$BENCH_DIR/run.sh" "$@"
+fi
+
 TOOLS="osm-pbf-parquet,duckdb,osm-parquetizer,osm2orc"
 WORKERS=8
 NICENESS=10
@@ -64,6 +78,39 @@ device_for_path() {
 IN_DEV=$(device_for_path "$(dirname "$INPUT")")
 OUT_DEV=$(device_for_path "$OUTPUT")
 echo "input device: $IN_DEV, output device: $OUT_DEV"
+
+# Record what actually produced these numbers. Wrappers resolve their binary
+# from config.env or fall back to PATH, so a summary alone does not say which
+# build was measured. Probed here rather than in the wrappers to keep it out of
+# the timed window.
+java_version() {
+    local java="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+    command -v "$java" >/dev/null 2>&1 || { echo "java not found"; return; }
+    "$java" -version 2>&1 | head -1
+}
+
+tool_version() { # tool -> "<resolved> | <version>"
+    case "$1" in
+        osm-pbf-parquet)
+            local bin="${OSM_PBF_PARQUET_BIN:-$BENCH_DIR/../target/release/osm-pbf-parquet}"
+            echo "$bin | $("$bin" --version 2>&1 | head -1)" ;;
+        duckdb|duckdb-s3)
+            local bin="${DUCKDB_BIN:-duckdb}"
+            echo "$bin | $("$bin" -csv -noheader -c 'select version();' 2>/dev/null || echo unknown)" ;;
+        sedona|sedona-s3)
+            # pinned in the wrapper's uv invocation
+            echo "uv | $(grep -o 'apache-sedona\[spark\]==[0-9.]*' "$BENCH_DIR/tools/sedona.sh" | head -1), \
+$(grep -o 'pyspark==[0-9.]*' "$BENCH_DIR/tools/sedona.sh" | head -1)" ;;
+        osm2orc)     echo "${OSM2ORC_BIN:-unset} | $(java_version)" ;;
+        osm-parquetizer) echo "${PARQUETIZER_JAR:-unset} | $(java_version)" ;;
+        *)           echo "unknown" ;;
+    esac
+}
+
+for tool in ${TOOLS//,/ }; do
+    printf '%s\t%s\n' "$tool" "$(tool_version "$tool")"
+done > "$RESULTS/versions.txt"
+echo "tool versions -> $RESULTS/versions.txt"
 
 SUMMARY="$RESULTS/summary.tsv"
 echo -e "tool\twall_s\tuser_s\tsys_s\tcpu_pct\tmax_rss_mb\tout_bytes\tout_files\tin_dev_r_mbps\tout_dev_w_mbps" > "$SUMMARY"

--- a/bench/tools/sedona_job.py
+++ b/bench/tools/sedona_job.py
@@ -5,8 +5,8 @@ Usage: sedona_job.py <input.osm.pbf> <outdir> <workers>
 hadoop-aws package and points fs.s3a at the bench MinIO endpoint
 (defaults below, env-overridable); local output is unchanged.
 Env: SPARK_DRIVER_MEMORY (default 24g), SEDONA_PACKAGE (maven coordinate),
-HADOOP_AWS_PACKAGE, BENCH_S3_ENDPOINT, BENCH_S3_ACCESS_KEY,
-BENCH_S3_SECRET_KEY, BENCH_S3_REGION
+SEDONA_MAX_PARTITION_BYTES (default 128MB), HADOOP_AWS_PACKAGE,
+BENCH_S3_ENDPOINT, BENCH_S3_ACCESS_KEY, BENCH_S3_SECRET_KEY, BENCH_S3_REGION
 """
 import os
 import sys
@@ -49,6 +49,12 @@ builder = (
     .master(f"local[{workers}]")
     .config("spark.driver.memory", driver_mem)
     .config("spark.jars.packages", packages)
+    # Read+write is one stage, so this sets split count, task parallelism and
+    # output file count together. Default matches Spark's own 128MB.
+    .config(
+        "spark.sql.files.maxPartitionBytes",
+        os.environ.get("SEDONA_MAX_PARTITION_BYTES", "134217728"),
+    )
     .config("spark.sql.parquet.compression.codec", "zstd")
     .config("spark.io.compression.zstd.level", "3")
     .config("parquet.compression.codec.zstd.level", "3")


### PR DESCRIPTION
Implements #36.

- `run.sh` re-execs inside a `systemd-run --user --scope` under `user@<uid>.service` when it detects it is outside that subtree. Migrating into a per-tool cgroup needs write access to the `cgroup.procs` of the common ancestor of the source and destination cgroups, which a login or SSH session scope does not have. A probe distinguishes "no usable user manager" — fall through to the existing rusage behavior — from a benchmark failure, and `--same-dir` keeps relative `--output` paths working. Verified end to end: a run now leaves a `<tool>.peak_anon` and no `<tool>.cgroup_failed`.
- `config.env.example` pins an explicit DuckDB version instead of the floating `latest` symlink.
- `sedona_job.py` exposes `SEDONA_MAX_PARTITION_BYTES`. The default is Spark's own 128MB, so existing runs are unchanged.
- `bench/README.md` documents what the summary columns measure, why file counts are not comparable across tools, the per-column noise floor, and the measured cost of Sedona's partition sizing.

No tool's measured configuration changes, so the numbers currently in the top-level README stand.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
